### PR TITLE
7.3 — Create Architecture Decision Records (ADR) template and process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,10 +175,12 @@ Separate each group with a blank line.
 2. **SonarQube:** Code must pass the quality gate before PR can be merged.
 3. **Human review:** Every PR requires at least one approved review.
 4. **No merge without approval.** No exceptions.
-5. **PR checklist:**
+5. **Architecture Decision Records (ADRs):** Any decision that affects project structure, adds or removes a major dependency, locks in a pattern other code will follow, or has a hard-to-reverse cost must be captured as an ADR in [`docs/adrs/`](docs/adrs/). Use the template at `docs/adrs/000-template.md`. ADRs are short (200–500 words) and never deleted — superseded ADRs stay in the repo with a pointer to their replacement. New developers should read every ADR before touching the codebase.
+6. **PR checklist:**
    - [ ] Tests pass locally
    - [ ] Coverage >= 80%
    - [ ] Lint passes (`npm run lint`)
    - [ ] Type check passes (`npx tsc --noEmit`)
    - [ ] Build succeeds (`npm run build`)
    - [ ] Self-review completed
+   - [ ] If the PR contains a non-trivial architectural decision, an ADR is included

--- a/docs/adrs/000-template.md
+++ b/docs/adrs/000-template.md
@@ -1,0 +1,54 @@
+# NNN — [Short noun phrase, e.g., "Use Postgres JSONB for flexible customer fields"]
+
+- **Status:** proposed | accepted | deprecated | superseded by NNN
+- **Date:** YYYY-MM-DD
+- **Deciders:** [names of people who agreed to this decision]
+
+## Context
+
+What is the issue we're facing? What constraints or pressures are driving the need for a decision? Two or three short paragraphs. Be specific — link to tickets, incidents, or external constraints.
+
+## Options considered
+
+### Option A — [Name]
+- **Pros:** [bullet points]
+- **Cons:** [bullet points]
+
+### Option B — [Name]
+- **Pros:** [bullet points]
+- **Cons:** [bullet points]
+
+### Option C — [Name]
+- **Pros:** [bullet points]
+- **Cons:** [bullet points]
+
+(Add or remove options as needed. If only one option was seriously considered, say so and explain why others were ruled out before evaluation.)
+
+## Decision
+
+We chose **Option [letter] — [name]**.
+
+Explain the reasoning in 2–4 sentences. Reference the specific tradeoffs from the Options section that drove the call. If the decision was contested, note who disagreed and why.
+
+## Consequences
+
+### What becomes easier
+- [bullet points]
+
+### What becomes harder
+- [bullet points]
+
+### What we'll need to revisit
+- [conditions under which we'd reopen this decision, e.g., "if request volume exceeds 10k/sec, the JSONB approach will need a rewrite"]
+
+## References
+
+- Ticket: [link]
+- PR: [link]
+- Discussion: [link to Slack thread, doc, or meeting notes]
+- Related ADRs: [list]
+- External: [docs, blog posts, RFCs that informed the decision]
+
+---
+
+> **Note for ADR authors:** Once this ADR is `accepted`, do not edit the Context, Options, or Decision sections. They are the historical record. The Consequences section may be appended with later observations, prefixed with a date.

--- a/docs/adrs/001-use-react-18-with-typescript.md
+++ b/docs/adrs/001-use-react-18-with-typescript.md
@@ -1,0 +1,58 @@
+# 001 — Use React 18 with TypeScript (strict mode)
+
+- **Status:** accepted
+- **Date:** 2026-04-08
+- **Deciders:** Tanay, Chinmay
+
+## Context
+
+Every project we build at Agent Space is a customer-facing dashboard or internal tool with rich interactivity (filters, charts, tables, forms). We needed to pick a single frontend stack so that the dev template, the team's skills, and Claude Code's instructions could all converge on one set of patterns. Having one stack means cross-project review, shared components, and onboarding are all cheaper.
+
+The team has prior production experience with React and Vue. Tanay has shipped React apps for the last four years; Chinmay's Power Apps work also leans on JavaScript/TypeScript. No one on the team has Svelte or Solid experience.
+
+## Options considered
+
+### Option A — React 18 + TypeScript (strict)
+- **Pros:** Largest ecosystem; strongest hiring pool in India; TypeScript catches whole classes of bugs at compile time; React 18 concurrent rendering helps with the chart-heavy dashboards we build; matches the team's existing skill set.
+- **Cons:** Larger bundle than Svelte/Solid; React 19 was on the horizon (now released and adopted in newer template versions); strict mode discipline takes effort to maintain.
+
+### Option B — Vue 3 + TypeScript
+- **Pros:** Single-file components are arguably cleaner; smaller learning curve for new devs; good TS support since Vue 3.
+- **Cons:** Smaller ecosystem in our specific niche (admin dashboards); fewer ready-made charting libraries with Vue bindings; team's React experience would be wasted; harder to find Vue devs in India.
+
+### Option C — Svelte + TypeScript
+- **Pros:** Smallest bundle; best DX for greenfield projects; compile-time reactivity is elegant.
+- **Cons:** Ecosystem is thin for enterprise dashboards; no team experience; higher hiring risk; charting libraries are immature; Claude Code has weaker training data on Svelte than React.
+
+### Option D — Plain JavaScript (no TypeScript)
+- **Pros:** Lower barrier; no build complexity for types.
+- **Cons:** Customer dashboards have data shape rules that *must* be enforced; without types, bugs ship to production. Ruled out at the outset.
+
+## Decision
+
+We chose **Option A — React 18 + TypeScript with strict mode**.
+
+The deciding factors were team skill alignment (React experience compounds across projects), ecosystem maturity (Recharts, React Query, React Hook Form, React Testing Library, MSW are all best-in-class), and the fact that Claude Code performs measurably better on React+TS than on alternatives. Strict mode is non-negotiable — half the value of TypeScript disappears without it.
+
+## Consequences
+
+### What becomes easier
+- Cross-project component reuse (KPICard, DataTable, ChartCard live in the template)
+- Hiring — large pool of React+TS engineers
+- Refactors are safer because the type checker catches breakage early
+- Claude Code generates better code on first try
+
+### What becomes harder
+- Bundle size requires active management (code splitting, lazy loading)
+- Strict mode requires discipline; `any` is forbidden by `CLAUDE.md` Section 6
+- React 18 → 19 migration will eventually need its own ADR
+
+### What we'll need to revisit
+- If a project specifically needs SSR-first or sub-100KB bundles, React may not be the right fit and we'd reopen this decision.
+- React 19 adoption will trigger a successor ADR.
+
+## References
+
+- CLAUDE.md Section 2 (Tech Stack)
+- skills/frontend.md
+- React 18 release notes: https://react.dev/blog/2022/03/29/react-v18

--- a/docs/adrs/002-tailwind-over-custom-css.md
+++ b/docs/adrs/002-tailwind-over-custom-css.md
@@ -1,0 +1,64 @@
+# 002 — Tailwind CSS over custom CSS files
+
+- **Status:** accepted
+- **Date:** 2026-04-08
+- **Deciders:** Tanay, Chinmay
+
+## Context
+
+Every project we ship has the same frontend problem: a designer (Tanay) hands over an HTML/Figma mockup, and a developer (or Claude) needs to translate it into reusable components without spending half the budget on CSS plumbing. Custom CSS at past gigs led to bloated stylesheets, naming conflicts, dead rules nobody could safely delete, and `!important` wars during the final QA crunch.
+
+We needed a styling approach that:
+
+1. Lets a developer match a Figma design without inventing a class hierarchy
+2. Stays in the JSX/TSX file so reviewers can see styling and structure together
+3. Doesn't allow specificity to grow over time
+4. Works well with Claude Code's pattern-matching strengths
+
+## Options considered
+
+### Option A — Tailwind CSS (utility-first)
+- **Pros:** No naming required; co-located with markup; PurgeCSS removes unused utilities so production CSS stays small; design tokens (colors, spacing, fonts) live in one config; Claude Code has very strong training data; easy to enforce consistency by listing allowed classes.
+- **Cons:** Long `className` strings can hurt readability for complex components; learning curve for devs who haven't seen utility-first; designer–developer handoff still requires translation from Figma values to Tailwind tokens.
+
+### Option B — CSS Modules
+- **Pros:** Real CSS, no new syntax; class names are scoped automatically; works with any CSS preprocessor.
+- **Cons:** Still requires inventing names for every visual variant; styling lives in a separate file from the component, so reviewers context-switch; design token enforcement is manual.
+
+### Option C — CSS-in-JS (styled-components, Emotion)
+- **Pros:** Co-located with components; full power of JS for dynamic styles; theme support is first-class.
+- **Cons:** Runtime cost (bundle + parse + style injection); React Server Components story is messy; team has had pain with this in past projects; the React team itself has discouraged it for new code.
+
+### Option D — Plain CSS files with BEM or similar
+- **Pros:** Familiar to everyone; no build chain.
+- **Cons:** Naming discipline always slips; dead code accumulates; the exact pattern we wanted to escape.
+
+## Decision
+
+We chose **Option A — Tailwind CSS**.
+
+Co-location with JSX (developer can see structure + styling in one file) and the absence of naming overhead were the deciding factors. The "long className strings" concern is real but mitigated by extracting components when a class string starts to feel oppressive — that's the right pressure release valve. Tailwind's PurgeCSS keeps shipped CSS small, and the team has standardized on `tailwind-merge` + `clsx` for conditional classes.
+
+## Consequences
+
+### What becomes easier
+- Pixel-matching a Figma design without inventing classes
+- Code review (everything is in the component file)
+- Removing dead styles (deleting a component deletes its styles)
+- Enforcing the design system (the `tailwind.config.js` / `@theme` block is the single source of truth for colors, spacing, fonts)
+
+### What becomes harder
+- Onboarding a developer who has never used Tailwind
+- Reading components with very long `className` strings — extract sub-components when this happens
+- Switching design systems mid-project (a token rename touches many files)
+
+### What we'll need to revisit
+- If we adopt React Server Components heavily, we may need to revisit the styling approach (Tailwind v4 already handles this well so this is unlikely).
+- If a client requires shipping a specific design system that's already coded against another solution (e.g., MUI), we'd write a per-project ADR overriding this one.
+
+## References
+
+- ADR 001 — Use React 18 with TypeScript
+- CLAUDE.md Section 6 (no inline styles)
+- skills/frontend.md (Tailwind CSS Rules section)
+- Tailwind v4 release notes: https://tailwindcss.com/blog/tailwindcss-v4

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,82 @@
+# Architecture Decision Records
+
+This directory holds the **Architecture Decision Records (ADRs)** for projects cloned from the Agent Space dev template. ADRs capture the *why* behind significant technical decisions so future developers (and future-you) don't have to guess or play archaeology with git history.
+
+## What is an ADR?
+
+An ADR is a short markdown document that records:
+
+1. **The context** — what was the problem or pressure that forced a decision?
+2. **The options** — what alternatives were considered, and what were their tradeoffs?
+3. **The decision** — what we picked and why.
+4. **The consequences** — what becomes easier and harder because of the choice.
+
+That's it. ADRs are not design documents, technical specs, or implementation guides. They are a paper trail for decisions, written at the moment of the decision, and never deleted.
+
+The format used here is based on Michael Nygard's original [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) post (2011), with minor adaptations for our process.
+
+## When to write one
+
+**Write an ADR when the decision:**
+
+- Affects the project structure (folder layout, module boundaries, build system)
+- Adds, removes, or replaces a major dependency (frameworks, runtimes, databases)
+- Locks in a pattern that other code will follow (state management, data fetching, error handling)
+- Has a cost that's hard to reverse (database schema, API contracts, auth model)
+- Was contested or had a non-obvious tradeoff that future devs will question
+
+**Do NOT write an ADR for:**
+
+- Implementation details inside a single file or function
+- Naming choices that don't affect external APIs
+- Dependency *upgrades* (those are tracked in PR descriptions; see `docs/dependency-upgrades.md`)
+- Trivial choices that can be reversed in a single PR without breaking other code
+
+If you're unsure, the test is: *"In six months, will a new developer ask why we did this?"* If yes, write an ADR. If no, skip it.
+
+## Numbering
+
+ADRs are numbered sequentially starting at `001`. **Numbers are never reused.** If an ADR is superseded, the number stays — the file gets a new status and a link to the replacement.
+
+File naming: `NNN-short-kebab-case-title.md`
+
+Examples:
+- `001-use-react-18-with-typescript.md`
+- `002-tailwind-over-custom-css.md`
+- `015-postgres-jsonb-for-flexible-customer-fields.md`
+
+## Status lifecycle
+
+Every ADR has a `Status` field at the top. The valid values are:
+
+| Status | Meaning |
+|---|---|
+| `proposed` | Drafted but not yet agreed. Open for comment. |
+| `accepted` | Decision is in effect. Code should follow it. |
+| `deprecated` | No longer recommended, but no replacement yet. |
+| `superseded by NNN` | Replaced by ADR number NNN. The newer ADR explains why. |
+
+Once accepted, **never edit the Context, Options, or Decision sections** — those are the historical record. If the situation changes, write a new ADR that supersedes the old one.
+
+You *may* edit the `Consequences` section to add observations as they emerge ("update 2026-08-01: this caused issue X, mitigated by Y").
+
+## How to write a new ADR
+
+1. Pick the next free number by counting the highest existing file in this directory and adding 1.
+2. Copy `000-template.md` to `NNN-your-title.md`.
+3. Fill in every section. If a section doesn't apply, write *"N/A — explain why"* rather than leaving it blank.
+4. Keep it short. **Target 200–500 words.** ADRs are not essays.
+5. Open a PR with the new ADR. Reviewers focus on whether the *decision* is sound, not whether the prose is polished.
+6. When merged, the ADR is canon. Code reviewers may cite it in future PRs.
+
+## Reading order for new developers
+
+If you're joining a project mid-way, read every ADR in this directory in numerical order before touching the codebase. They are the shortest path to understanding why the project looks the way it does. After you've read them, ask the team about any decisions that weren't recorded — those are the ones most likely to bite you.
+
+## Cross-references
+
+- **Template:** [`000-template.md`](./000-template.md)
+- **Architecture overview:** [`../architecture.md`](../architecture.md) — describes the *current* state, while ADRs describe how we got there.
+- **Dependency upgrades:** [`../dependency-upgrades.md`](../dependency-upgrades.md) — major upgrades require an ADR per the playbook.
+- **Original ADR post:** [Michael Nygard, 2011](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- **More examples:** [adr.github.io](https://adr.github.io)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # System Architecture — The 4-Layer Workflow
 
+> **Looking for the *why* behind specific decisions?** This document describes the *current* architecture. The decisions that shaped it — and the alternatives that were considered and rejected — live in [`adrs/`](./adrs/). New developers should read every ADR before making non-trivial changes.
+
 ## Overview
 
 Every task at Agent Space flows through the same 4 layers, regardless of which product is being built or which developer is doing the work.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -89,9 +89,13 @@ After every coding task, before creating a PR, copy the self-review prompt from 
 
 Once comfortable with single-terminal Claude Code, read `docs/multi-terminal-workflow.md` to learn how to run 4 parallel sessions for approximately 4x productivity.
 
+## Step 9: Read the Architecture Decision Records
+
+Before you make non-trivial changes to the codebase, read every ADR in [`docs/adrs/`](./adrs/) in numerical order. They are short (200–500 words each) and capture the *why* behind the project's biggest technical decisions — what was considered, what was picked, and what tradeoffs we accepted. Reading them is the fastest way to understand "why does the code look like this?" without having to ask the original author. ADRs you write or amend yourself follow the process documented in [`docs/adrs/README.md`](./adrs/README.md).
+
 ## Getting Help
 
 - **Stuck on a task?** Ask Claude first, then your PM.
-- **Architecture question?** Check `docs/architecture.md`, then ask the tech lead.
+- **Architecture question?** Check `docs/architecture.md` and `docs/adrs/`, then ask the tech lead.
 - **Process question?** Ask your PM.
 - **Blocked by missing info?** Create a blocker comment on the GitHub Issue and flag it at standup.


### PR DESCRIPTION
## Summary
- Adds `docs/adrs/` with the README explaining when to write ADRs, the lifecycle, numbering convention, and reading order for new devs.
- Adds `docs/adrs/000-template.md` based on Michael Nygard's original ADR format with Status, Context, Options, Decision, Consequences, References sections.
- Adds two example ADRs (backdated to 2026-04-08, the day the team made these calls) demonstrating the format end-to-end:
  - **001 — Use React 18 with TypeScript** — captures the React vs Vue vs Svelte vs plain JS decision
  - **002 — Tailwind over custom CSS** — captures the Tailwind vs CSS Modules vs CSS-in-JS vs plain CSS decision
- Links the directory from `docs/architecture.md` (current state vs decision history).
- Adds an ADR rule to `CLAUDE.md` Section 9 with PR checklist update.
- Adds Step 9 to `docs/onboarding.md` requiring new devs to read all ADRs before non-trivial changes.

## Test plan
- [ ] Each ADR follows the template and is under 1 page
- [ ] `architecture.md` and `CLAUDE.md` references resolve
- [ ] Onboarding flow is coherent end-to-end (Steps 1–9)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)