### PR TITLE
7.2 — Create incident response runbook template

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -89,9 +89,20 @@ After every coding task, before creating a PR, copy the self-review prompt from 
 
 Once comfortable with single-terminal Claude Code, read `docs/multi-terminal-workflow.md` to learn how to run 4 parallel sessions for approximately 4x productivity.
 
+## Step 9: Read the runbooks before you need them
+
+Open [`docs/runbooks/`](./runbooks/) and skim:
+
+- [`deployment-runbook.md`](./runbooks/deployment-runbook.md) — read this before your first production deploy
+- [`incident-response.md`](./runbooks/incident-response.md) — read this **now**, while nothing is broken. The first time you read it should not be at 2am during an outage.
+- [`postmortem-template.md`](./runbooks/postmortem-template.md) — used within 48h of any SEV1 or SEV2
+
+You don't need to memorize them. You need to know they exist and where they live.
+
 ## Getting Help
 
 - **Stuck on a task?** Ask Claude first, then your PM.
 - **Architecture question?** Check `docs/architecture.md`, then ask the tech lead.
+- **About to deploy or in an incident?** Open the relevant runbook in `docs/runbooks/` and follow it step by step.
 - **Process question?** Ask your PM.
 - **Blocked by missing info?** Create a blocker comment on the GitHub Issue and flag it at standup.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,58 @@
+# Runbooks
+
+This directory contains **operational runbooks** — step-by-step procedures the team follows during real, time-sensitive operations: deploys, incidents, rollbacks, recovery from outages.
+
+## Runbooks vs skill files vs ADRs
+
+The team has three different documentation surfaces, and they answer different questions. Knowing which one to read (or write) saves a lot of confusion:
+
+| Surface | Question it answers | When you read it | Tone |
+|---|---|---|---|
+| **`skills/`** | *How do I write code that follows our patterns?* | While coding, before a PR | Conceptual, with examples |
+| **`docs/adrs/`** | *Why does the project look the way it does?* | Onboarding, before refactoring | Historical, explains tradeoffs |
+| **`docs/runbooks/`** (you are here) | *What do I do, right now, in this exact situation?* | During a deploy, an incident, an outage | Imperative, copy-pasteable |
+
+A skill file might say *"use multi-stage Docker builds"*. The deployment runbook tells you *"step 3: run `docker build --target=production -t app:$(git rev-parse --short HEAD) .`"*. Different question, different answer.
+
+## When to write a runbook
+
+Write a runbook when:
+
+- The procedure is **operational** (you run it, not write it)
+- The procedure is **time-sensitive** (someone needs it at 2am, half-asleep)
+- The procedure has **decision points** ("if X, do Y; if Z, escalate")
+- The procedure has **rollback or recovery** steps
+- The cost of a mistake is high (production deploys, schema migrations, incident response)
+
+If a procedure is run rarely and casually (quarterly dependency upgrade review, etc.), a doc in `docs/` is enough. Reserve runbooks for the things you'd want a printed copy of when the network is down.
+
+## Runbook standards
+
+Every runbook in this directory follows the same shape so a half-asleep engineer can find what they need:
+
+1. **Owner** — which team or rotation maintains it
+2. **When to use this runbook** — concrete trigger conditions
+3. **Pre-conditions / pre-flight checklist** — what must be true before you start
+4. **Steps** — numbered, copy-pasteable, with timing estimates
+5. **Verification** — how you know each step worked
+6. **Rollback** — how to undo, with a clear point-of-no-return marker if there is one
+7. **Known issues** — common failures and their fixes
+8. **Escalation** — who to page if you're stuck
+
+Write runbooks in the second person (*"You will run..."*), present tense, and assume the reader is in a hurry. Cut every word that isn't load-bearing.
+
+## Current runbooks
+
+| File | Purpose | Owner |
+|---|---|---|
+| [`deployment-runbook.md`](./deployment-runbook.md) | Production deploys (any project cloned from this template) | On-call engineer |
+| [`incident-response.md`](./incident-response.md) | First-10-minutes response to a production incident, severity definitions, comms protocol, resolution flow | On-call engineer |
+| [`postmortem-template.md`](./postmortem-template.md) | Blameless postmortem template for use within 48 hours of any SEV1 or SEV2 incident | Incident commander |
+
+## Cross-references
+
+- **Skill files:** [`../../skills/`](../../skills/) — patterns and conventions
+- **ADRs:** [`../adrs/`](../adrs/) — historical decisions
+- **CLAUDE.md:** [`../../CLAUDE.md`](../../CLAUDE.md) — master instructions for Claude Code
+- **Google SRE Book — Writing Runbooks:** https://sre.google/sre-book/being-on-call/
+- **PagerDuty incident response guide:** https://response.pagerduty.com/

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,246 @@
+# Incident Response Runbook
+
+> **Owner:** On-call engineer
+> **Pairs with:** [`postmortem-template.md`](./postmortem-template.md) (use within 48h of any SEV1 or SEV2)
+> **First read:** Now, while nothing is broken. Not at 2am.
+
+This runbook is the canonical first-10-minutes procedure for any production incident on an Agent Space project. It exists so that when something is on fire, you don't have to invent a process — you just follow the steps.
+
+**Print or bookmark this. Don't try to find it during an incident.**
+
+## When to use this runbook
+
+You should be following this runbook the moment any of these is true:
+
+- A user-visible feature is broken in production
+- The error rate has spiked above the alerting threshold
+- A deploy has caused a regression that wasn't caught by the [deployment runbook](./deployment-runbook.md)
+- The status page is showing a green status but reality is showing red
+- Customer support is reporting a flood of complaints about the same thing
+
+If you're not sure whether something is an incident, **assume it is** and follow the runbook. The cost of treating a non-incident as an incident is 10 minutes of process. The cost of the reverse is much higher.
+
+## Severity levels
+
+The first decision in any incident is the severity. It determines who you wake up and how fast.
+
+| Level | Definition | Response time | Examples |
+|---|---|---|---|
+| **SEV1** | Total outage, data loss, or security breach. The product is unusable for most users. | **5 minutes.** Page everyone. | Site is down, database is corrupted, auth is fully broken, secret is leaked |
+| **SEV2** | Significant feature is broken. A meaningful subset of users cannot accomplish a meaningful workflow. | **30 minutes.** Page on-call + tech lead. | Search returns no results, exports time out, login is intermittent, key page won't load |
+| **SEV3** | Degraded experience. Users can work around it. | **1 business day.** Async ticket. | A chart renders wrong, a non-critical button doesn't work, a metric is slow |
+
+If you're between two levels, **pick the higher one**. You can downgrade. Upgrading mid-incident wastes the most valuable resource (the first 10 minutes).
+
+## First 10 minutes — the checklist
+
+**Walk through every step.** Don't skip ahead.
+
+### 0:00 — 0:30 — Acknowledge
+
+- [ ] Acknowledge the alert (in PagerDuty / Sentry / wherever it came from). This stops the page from re-firing and tells the rest of the team someone is on it.
+- [ ] Open the team channel (`#incidents` if it exists, otherwise the main team channel)
+- [ ] Post a quick hold message:
+
+```
+🚨 Investigating possible incident — alert: <link or summary>. More in 5 min. — <your name>
+```
+
+The point of this message is **not** to communicate the problem. It's to tell the team that you've seen the alert and are looking. Without it, three other people will wake up and start investigating in parallel.
+
+### 0:30 — 2:00 — Assess severity
+
+- [ ] What's broken? Be specific. "Login" is too vague. "Login form returns 500 on submit for users on the password flow" is useful.
+- [ ] Who is affected? "All users" or "users on plan X" or "one customer in Brazil"?
+- [ ] How bad is it? Pick a SEV level using the table above.
+- [ ] Are users actively losing data or money? If yes, this is SEV1 regardless of other factors.
+
+### 2:00 — 5:00 — Open the incident
+
+- [ ] Create a thread or new channel for the incident. Pin or link it from the team channel.
+- [ ] Start the incident timeline doc. This is the running record of what happened, when, and who did what. The simplest format works:
+
+```
+## Incident: <one-line description>
+- Severity: SEVx
+- Started: 2026-04-11 14:23 IST (when the alert fired)
+- Detected: 2026-04-11 14:25 IST (when a human noticed)
+- Incident commander: <your name>
+
+### Timeline
+14:25 — Alert fired (Sentry: Foo.tsx:42 ReferenceError)
+14:26 — IC acknowledged
+14:28 — Severity assessed as SEV2
+14:31 — ...
+```
+
+- [ ] Assign roles (for SEV1 or SEV2):
+  - **Incident Commander (IC)** — runs the incident, makes decisions, NOT the same person debugging
+  - **Investigator** — actually digs into the code/logs/dashboards
+  - **Communicator** — posts updates to the team channel and status page
+  - For SEV3, one person can be all three.
+
+### 5:00 — 8:00 — Initial investigation
+
+- [ ] Check Sentry / error tracker for recent error groups. Has anything spiked in the last 30 minutes?
+- [ ] Check the [deploy log](./deployment-runbook.md). Was there a deploy in the last hour? **A recent deploy is the most likely cause of any sudden incident.**
+- [ ] Check the dependency status: backend API health endpoint, database, CDN, DNS, Sentry itself.
+- [ ] Check the Lighthouse / performance dashboard if it's a slowness issue.
+- [ ] Reproduce the issue in an incognito browser if possible. Confirm it's not just one user's cache.
+
+**If a recent deploy is the cause, your first instinct should be to roll back.** Investigate later. Rollback procedure is in the [deployment runbook](./deployment-runbook.md). The rule is: **mitigate first, fix later.**
+
+### 8:00 — 10:00 — Communicate
+
+- [ ] Post the first real status update to the team channel. Use this template:
+
+```
+🔴 SEVx incident open
+What's broken: <one sentence, user-visible>
+Impact: <who is affected, how>
+Started: <time>
+What we know: <2-3 bullets>
+What we're doing: <2-3 bullets>
+Next update: in 15 minutes (or when the situation changes)
+IC: <name>
+```
+
+- [ ] If SEV1 or any customer-facing impact: update the status page (if the project has one)
+- [ ] If SEV1: alert the PM so they can prepare customer comms
+
+## Investigation steps (after the first 10 minutes)
+
+Now you have a few minutes to think. Work the problem.
+
+### Common investigation paths
+
+**"Errors started 30 minutes ago"**
+1. What deployed in the 30 minutes before the errors started?
+2. Roll back the deploy. Verify errors stop.
+3. Open a ticket for the actual fix.
+
+**"Page is slow"**
+1. Check the Lighthouse dashboard
+2. Check the backend API latency
+3. Check CDN status
+4. Check the user's region — could be a regional CDN issue
+
+**"Login is broken"**
+1. Check the auth provider's status page
+2. Check if the JWT signing key has rotated
+3. Check `VITE_API_BASE_URL` is correct in the production env
+4. Check CORS errors in the browser console
+
+**"Data is wrong / missing"**
+1. **STOP. Do not roll back yet** — a rollback may make data loss worse.
+2. Check whether the bad data is being written or just displayed wrong.
+3. If being written: page Chinmay immediately. Stop new writes if possible (feature flag the affected flow off).
+4. If just displayed wrong: rollback is safe.
+
+**"Sentry is showing errors but users aren't complaining"**
+1. Check the error volume vs baseline. A 2× spike from a low base may not be customer-impacting.
+2. Check whether the error is in a code path that has a fallback.
+3. Don't assume "no complaints = no impact." Some users just leave.
+
+## Communication protocol
+
+### Cadence
+
+- **SEV1:** team channel update **every 15 minutes** until resolved
+- **SEV2:** team channel update **every 30 minutes** until resolved
+- **SEV3:** post when the issue is identified and again when resolved — no scheduled cadence
+
+Even if there's nothing new to say, post: *"Still investigating. No new info. Next update in 15 min."* Silence makes everyone assume the worst.
+
+### Who to notify by severity
+
+| Level | Initial page | Updates | Resolution |
+|---|---|---|---|
+| SEV1 | On-call + Tech lead (Chinmay) + PM + Frontend lead (Tanay) | Team channel + DM to PM | Team channel + PM + customer success |
+| SEV2 | On-call + Tech lead (Chinmay) | Team channel | Team channel |
+| SEV3 | On-call | Team channel | Team channel |
+
+### Customer comms templates
+
+**Status page — initial (SEV1 or SEV2 with customer impact):**
+
+```
+We are investigating reports of <one sentence — user-visible problem>.
+Some users may experience <impact>. We are working on a fix and will
+post another update within 30 minutes.
+```
+
+**Status page — update:**
+
+```
+Update: We have identified the cause of <issue>. <What's being done.>
+We expect resolution within <time>. Next update: <time>.
+```
+
+**Status page — resolved:**
+
+```
+Resolved: <Issue> has been resolved as of <time>. Affected users may
+need to refresh their browser. We will publish a postmortem within 48
+hours.
+```
+
+Keep customer-facing language **factual, non-defensive, and short**. Don't apologise excessively. Don't blame anyone. Don't promise things you can't deliver.
+
+## Resolution
+
+When you believe the incident is resolved:
+
+1. **Verify the fix works.** Re-run the manual test that caught the original problem. Watch metrics for 10 minutes after the fix lands. **Do not declare resolved until metrics have actually returned to baseline.**
+2. **Update the status page** with the resolved message.
+3. **Post the resolution to the team channel** with a one-paragraph summary:
+   ```
+   ✅ SEVx incident resolved at <time>.
+   What was broken: <one sentence>
+   Root cause: <one sentence — preliminary, full RCA in postmortem>
+   How fixed: <one sentence>
+   Total duration: <minutes>
+   Postmortem: scheduled for <time>
+   ```
+4. **Schedule the postmortem within 48 hours.** SEV1 and SEV2 always require a postmortem. SEV3 is optional based on the IC's judgment.
+5. **Close the incident channel** (or unpin the thread).
+
+## Post-incident
+
+Within 48 hours of any SEV1 or SEV2:
+
+- [ ] Schedule a 30-60 minute postmortem meeting. All on-call participants attend. PM and tech lead attend.
+- [ ] Use the [postmortem template](./postmortem-template.md) to structure the discussion and the writeup.
+- [ ] **Blameless.** The postmortem is about the system, not the people. If a postmortem is becoming about who screwed up, redirect it.
+- [ ] Action items get tickets, owners, and due dates. Action items without owners are wishes, not commitments.
+- [ ] Publish the postmortem to the team. Internal-facing for SEV2, customer-facing summary for SEV1 if there was external impact.
+
+## Roles cheat sheet
+
+When you're paged into a SEV1 or SEV2 with multiple people responding:
+
+| Role | Responsibility | What they do NOT do |
+|---|---|---|
+| **Incident Commander (IC)** | Runs the incident. Makes decisions. Coordinates. Decides when to escalate, when to roll back, when it's resolved. | Debug code. Read logs. Reproduce bugs. The IC's job is to coordinate, not to fix. |
+| **Investigator** | Reads logs, reproduces the bug, finds the root cause, writes the fix. | Communicate updates. Decide severity. The investigator should be heads-down, not context-switching. |
+| **Communicator** | Posts updates to team channel and status page on the cadence above. Drafts customer comms. | Investigate. Communicate is a full-time role during a SEV1. |
+
+For a SEV3 with one person, all three roles collapse into "you." For a SEV2, IC + Investigator is the minimum split. For a SEV1, all three should be different people.
+
+## What NOT to do during an incident
+
+- **Don't blame.** Even if you're sure who broke it. Blame slows down the response and poisons the postmortem. Time for accountability is *after*, in the postmortem, with system fixes.
+- **Don't solo-debug a SEV1.** Two people are 4× as fast, not 2×, because one of them notices the thing the other missed.
+- **Don't deploy fixes without verification.** The temptation to ship a "quick fix" is always strong. The quick fix often makes it worse. Verify the fix locally first.
+- **Don't skip the postmortem.** "We already know what happened" is exactly when you most need a structured postmortem to find the systemic issues.
+- **Don't communicate by DM.** Everything goes in the incident channel so the timeline is preserved. DMs are invisible and forgotten.
+- **Don't keep working past your effectiveness.** If you've been on for 4 hours straight, hand off. Tired investigators make mistakes.
+
+## Cross-references
+
+- [`deployment-runbook.md`](./deployment-runbook.md) — covers the rollback procedure that this runbook references
+- [`postmortem-template.md`](./postmortem-template.md) — the blameless postmortem template
+- `skills/security.md` — if the incident is a security breach, also follow the security incident escalation
+- `docs/logging.md` — how to read structured logs from the logger
+- Google SRE Book — Incident Management: https://sre.google/sre-book/managing-incidents/
+- PagerDuty Incident Response: https://response.pagerduty.com/

--- a/docs/runbooks/postmortem-template.md
+++ b/docs/runbooks/postmortem-template.md
@@ -1,0 +1,141 @@
+# Postmortem: [One-line description of the incident]
+
+> **This is a template.** Copy it to `docs/postmortems/YYYY-MM-DD-short-name.md` (create the directory if needed) and fill in every section. Delete this header.
+>
+> **Postmortems are blameless.** Focus on the systems and processes that allowed the incident, not on the individuals involved. If you find yourself writing "X should have known better," rephrase as "the system did not give X enough information to make a different decision." That is the actual problem to fix.
+
+## Metadata
+
+- **Severity:** SEV1 / SEV2 / SEV3
+- **Date:** YYYY-MM-DD
+- **Duration:** HH:MM (from first impact to resolution)
+- **Incident commander:** [name]
+- **Investigators:** [names]
+- **Authors of this document:** [names]
+- **Status:** draft / in review / final
+
+## Summary
+
+Two or three sentences. What broke, who was affected, how long it lasted, how it was fixed. Imagine someone reading only the summary — they should still understand the incident.
+
+Example: *"On 2026-04-08, between 14:23 and 15:11 IST, the shipping bill search returned 500 errors for all users. The cause was a missing index on the `shipping_bills.created_at` column after a migration. Resolved by adding the index. Approximately 230 users impacted, no data loss."*
+
+## Impact
+
+Be specific. Numbers, not adjectives.
+
+- **Users affected:** [count or "all users", or "users on plan X"]
+- **Duration of impact:** [HH:MM]
+- **Geographic scope:** [global / region / specific tenant]
+- **Data loss:** [yes / no — and if yes, how much and what]
+- **Revenue impact:** [if known and meaningful]
+- **Customer-visible:** [yes / no — were complaints filed?]
+
+## Timeline
+
+Use the live timeline kept in the incident channel. Cleaned up but **not** edited to make anyone look better. Honest timestamps.
+
+| Time (IST) | Event |
+|---|---|
+| 14:23 | Alert fired (Sentry: `BillSearch.tsx:42 ReferenceError`) |
+| 14:25 | On-call (Akshat) acknowledged |
+| 14:27 | Severity assessed as SEV2 |
+| 14:30 | Incident channel opened, IC assigned |
+| 14:35 | Identified that the issue started 5 min after the 14:18 deploy |
+| 14:38 | Decision: roll back the deploy |
+| 14:42 | Rollback complete; verified errors stopped |
+| 14:45 | Status page updated to "investigating" |
+| 14:51 | Status page updated to "monitoring" |
+| 15:11 | Incident declared resolved after 20-minute clean window |
+
+## Root cause analysis
+
+What actually caused the incident? Walk through the chain.
+
+**5 Whys** is a useful structure, but don't stop at the first technical answer. Push to the underlying systemic cause.
+
+Example:
+
+1. **Why did search return 500?** Because the database query timed out.
+2. **Why did the query time out?** Because there was no index on `shipping_bills.created_at`.
+3. **Why was there no index?** Because the migration that added the column didn't add the index.
+4. **Why didn't the migration add the index?** Because the developer wasn't aware that this column would be used as a query filter.
+5. **Why wasn't this caught in review?** Because the migration PR and the search PR were reviewed independently, and no reviewer was looking at the connection between them.
+
+The root cause here is **not** "the developer forgot the index." The root cause is **"the review process doesn't catch missing indexes when query filters and migrations are split across PRs."** That's the thing to fix.
+
+## Contributing factors
+
+Things that didn't directly cause the incident but made it worse or harder to detect.
+
+- The error rate alert threshold was set too high; the spike took 4 minutes to fire
+- The monitoring dashboard didn't show DB query latency on the main view
+- The on-call playbook didn't include "check recent migrations" as a common cause
+- ...
+
+## What went well
+
+This section is non-negotiable. Every postmortem includes it. The point is to identify the things you want to keep doing — celebrate them publicly so they become habit.
+
+- Alert fired within 4 minutes of impact
+- IC was assigned within 7 minutes of the alert
+- Rollback decision was made fast and was the right call
+- Communication on the status page was timely and clear
+- Total time to mitigation: 15 minutes (well within SLA)
+
+## What went wrong
+
+Process, tooling, and system failures only. Not individual mistakes.
+
+- The migration review didn't surface the missing index
+- The error rate alert took 4 minutes to fire (too high a threshold)
+- The communicator role wasn't assigned, so customer comms came late
+- We didn't have a runbook for "what to check when search times out"
+
+## Action items
+
+Concrete, owned, dated. No action items without all three.
+
+| # | Action | Owner | Due | Ticket |
+|---|---|---|---|---|
+| 1 | Add `created_at` index to `shipping_bills` table | Chinmay | 2026-04-12 | #88 |
+| 2 | Lower error rate alert threshold from 5% to 2% | Akshat | 2026-04-15 | #89 |
+| 3 | Add migration review checklist item: "any new column used as a query filter must have an index" | Chinmay | 2026-04-18 | #90 |
+| 4 | Add a "check recent migrations" step to the incident response runbook for DB-related incidents | Akshat | 2026-04-15 | #91 |
+| 5 | Add DB query latency to the main monitoring dashboard | Chinmay | 2026-04-30 | #92 |
+
+Vague action items are worthless. **"Improve testing"** is not an action item. **"Add a Cypress test for the search page filter happy path by 2026-04-20, owned by Tanay, ticket #93"** is.
+
+## Lessons learned
+
+Generalizable lessons that go beyond the specific incident.
+
+- "Review process needs to span related PRs, not just review them in isolation."
+- "Alert thresholds should be set based on user impact, not on internal noise tolerance."
+- "Every new column should be evaluated as 'will this be used in a WHERE clause' as part of migration review."
+
+These lessons should make their way into the relevant skill files, not just live in this postmortem. If a lesson is worth learning, it's worth codifying.
+
+## Sign-off
+
+- [ ] Postmortem reviewed by IC
+- [ ] Postmortem reviewed by tech lead
+- [ ] Action items have tickets
+- [ ] Action items have owners and due dates
+- [ ] Lessons learned have been added to the relevant skill files where applicable
+- [ ] Postmortem published to the team
+
+---
+
+## Appendix: blameless writing tips
+
+The phrase to internalize: **"Person X did Y" → "The system allowed Y to happen because Z"**.
+
+| Blameful (don't write) | Blameless (write this instead) |
+|---|---|
+| "Akshat forgot to add the index." | "The migration review process did not surface the missing index." |
+| "Tanay should have caught this in review." | "Two PRs that depend on each other were reviewed independently, with no mechanism to surface the dependency." |
+| "The on-call should have noticed sooner." | "The alert threshold was set too high; the alert fired 4 minutes after impact." |
+| "We need to be more careful." | "We need a checklist that catches this category of bug at review time." |
+
+The goal is not to make people feel good. The goal is to make the **system** better. A blameful postmortem teaches people to hide mistakes; a blameless one teaches the team to surface and fix them.


### PR DESCRIPTION
## Summary
- Adds `docs/runbooks/incident-response.md` covering severity definitions (SEV1/2/3 with response times and examples), the first-10-minutes checklist split into 30-second windows, common investigation paths, communication cadence and customer comms templates, the explicit "mitigate first, fix later" rollback rule, role definitions (IC / investigator / communicator), and a "what not to do during an incident" list.
- Adds `docs/runbooks/postmortem-template.md` — blameless template with metadata, impact, timeline, root cause via 5 whys (with the instruction to push past the first technical answer), what went well, what went wrong, action items table that requires owner + due date, lessons learned, sign-off checklist, and a blameless writing tips appendix.
- Extends `docs/runbooks/README.md` to list both new runbooks alongside the deployment runbook (overlaps the README content from PR #49 — git will auto-merge cleanly because the only change is the table row addition).
- Adds Step 9 to the onboarding guide telling new devs to read `incident-response.md` **now**, not at 2am.

## Test plan
- [ ] After the next real SEV1 or SEV2, the IC follows this runbook and reports back on what was missing
- [ ] After merge, the postmortem template is used for the next applicable incident — verify the action items section produces actionable items, not vague aspirations

## Notes
- This PR overlaps `docs/runbooks/README.md` with PR #49 (deployment runbook). The README content here is the superset (lists all 3 runbooks); whichever PR merges first, the other will rebase cleanly.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)