### PR TITLE
6.4 — Environment management and secrets handling template

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,162 @@
+# Environment Management
+
+This document covers how environment variables and secrets are managed across local, staging, and production for any project cloned from `agentspace-dev-template`. Read it once before configuring a new environment, then reference it when adding a new env var.
+
+For the security policy on what can and can't be exposed in client bundles, see [`skills/security.md`](../skills/security.md). For the secrets policy specifically, this document is the canonical reference.
+
+## The three environments
+
+| Environment | Where it runs | Source of vars | Bundle exposure |
+|---|---|---|---|
+| **local** | A developer's laptop, `npm run dev` | `frontend/.env.local` (gitignored) | Same as production — anything `VITE_*` is in the JS bundle |
+| **staging** | Hosting provider's staging deployment, auto-deployed from `develop` if used | Hosting provider secret manager | Same |
+| **production** | Hosting provider's production deployment, deployed from `main` | Hosting provider secret manager | Same |
+
+The most important rule: **`VITE_*`-prefixed variables are baked into the client JavaScript bundle at build time**. Anyone who downloads the JS can read them. They are public. Use `VITE_*` only for non-secret values: API base URLs, public DSNs (Sentry), public write keys (some analytics providers), and feature flag flags.
+
+**Real secrets** (database credentials, server-side API keys, signing keys) **never go in `VITE_*` variables.** They live on the backend and are accessed via authenticated API calls.
+
+## Local development setup
+
+When you clone the repo for the first time:
+
+```bash
+cd frontend
+cp .env.example .env.local
+# Open .env.local in your editor and fill in any blank values your local
+# backend needs.
+```
+
+`.env.local` is gitignored. Vite reads it automatically when you run `npm run dev`. The `check-env` script (see below) runs first and fails fast if anything required is missing.
+
+### Why `.env.local` and not `.env`?
+
+Because Vite's load order is `.env.local` > `.env`. We commit `.env.example` (the template) and `.gitignore` everything else. `.env.local` is the conventional place for per-developer overrides — your colleague's `.env.local` doesn't have to look like yours.
+
+## Staging and production setup
+
+Real staging and production secrets are **not** stored in any file in the repo. They live in the hosting provider's secret manager:
+
+- **Vercel:** Project Settings → Environment Variables, scoped to "Preview" or "Production"
+- **Netlify:** Site Settings → Environment Variables
+- **AWS Amplify:** Environment Variables in the app settings
+- **Cloud Run / GKE:** Cloud Secret Manager + Workload Identity
+- **Self-hosted:** systemd `EnvironmentFile=` or a sealed-secrets manifest
+
+The repo contains `frontend/.env.staging.example` and `frontend/.env.production.example` as **templates** — flat lists of every variable that environment needs. When you set up a new staging or production environment, copy that list into the secret manager so you don't miss any variables.
+
+## The `check-env` script
+
+`frontend/scripts/check-env.mjs` runs before `npm run dev` and `npm run build`. It validates that every required environment variable is:
+
+1. Set
+2. Non-empty
+3. Matching its expected format (URLs are checked for `https?://` prefix)
+
+If any check fails, the script prints a clear error and exits non-zero, blocking the dev server or the build. The error tells you exactly which variable is missing and why it's needed.
+
+### Adding a new required variable
+
+When you add a new `VITE_*` variable to the codebase:
+
+1. **Add it to `frontend/scripts/check-env.mjs`** in the `REQUIRED_VARS` array (or `PRODUCTION_REQUIRED_VARS` if it's only required in production):
+
+   ```js
+   {
+     name: 'VITE_FEATURE_X_ENDPOINT',
+     description: 'Endpoint for feature X — see docs/environments.md',
+     pattern: /^https?:\/\/.+/,
+   }
+   ```
+
+2. **Add it to `frontend/.env.example`** with a comment explaining what it's for and an example value (NOT a real secret).
+
+3. **Add it to `frontend/.env.staging.example` and `.env.production.example`** so future environment setups don't miss it.
+
+4. **Document it in this file** (next section) under the appropriate category.
+
+5. **Set it in every existing environment** (your local `.env.local`, the staging secret manager, the production secret manager) **before** merging the PR. A PR that adds a required variable but doesn't set it in production will break the deploy.
+
+## Variable catalog
+
+This is the source of truth for what every variable does. Keep it in sync with `.env.example`.
+
+### Required (all environments)
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `VITE_API_BASE_URL` | Backend REST API base URL. The `apiClient` in `frontend/src/lib/api.ts` prepends this to every request. | `https://api.example.com/api` |
+
+### Optional (added per ticket)
+
+| Variable | Purpose | Required when |
+|---|---|---|
+| `VITE_SENTRY_DSN` | Sentry DSN for client error reporting. Public — designed to be exposed in bundles. | Ticket #32 (Sentry) merged |
+| `VITE_SENTRY_ENVIRONMENT` | Tag added to all Sentry events. Defaults to `import.meta.env.MODE` if unset. | Ticket #32 merged |
+| `VITE_ANALYTICS_WRITE_KEY` | Public write key for the analytics provider. Leave blank to use the no-op implementation. | Ticket #40 (analytics) merged |
+| `VITE_FLAG_<NAME>` | Per-flag override for the feature flag system. See `frontend/src/lib/flags-config.ts`. | Per flag |
+
+## Secret rotation
+
+Secrets need to be rotated regularly. The cadence depends on the secret type:
+
+| Secret type | Rotation cadence | Triggered by |
+|---|---|---|
+| Backend API tokens | Every 90 days | Calendar reminder + cron alert |
+| Sentry auth tokens | Every 180 days | Calendar reminder |
+| Analytics write keys | Every 180 days | Calendar reminder |
+| Anything that has been exposed | Immediately | Incident |
+
+### Rotation process
+
+1. **Generate the new secret** in the upstream service (Sentry dashboard, analytics provider, etc.).
+2. **Add the new secret to the staging environment** in the secret manager. Do not delete the old one yet.
+3. **Trigger a staging deploy** so the new secret is in use.
+4. **Verify staging works** with the new secret (smoke test the affected feature).
+5. **Repeat steps 2-4 for production.**
+6. **Wait 24 hours** to make sure no old code paths are still using the old secret.
+7. **Revoke the old secret** in the upstream service.
+
+Document the rotation in the team channel: which secret, when, who did it. This is your audit trail.
+
+## What NEVER to commit
+
+This list is enforced by `.gitignore` (see [`skills/security.md`](../skills/security.md) for the full pattern list):
+
+- `.env`
+- `.env.local`
+- `.env.development`, `.env.staging`, `.env.production` (real values — only `.example` files are committed)
+- `.env.*.local`
+- `*.pem`, `*.key`, `*.crt`, `*.p12`
+- `secrets/`
+- Any file containing the literal string of a real API key, token, password, or DSN
+
+If a secret is committed by accident:
+
+1. **Treat it as compromised immediately.** It's now in git history, on every clone, in any forks, and possibly in GitHub's caches.
+2. **Rotate the secret right now** in the upstream service.
+3. **Purge from history** with `git filter-repo` (NOT `git rm` — that doesn't touch history).
+4. **Force-push** the cleaned history (with team coordination — everyone needs to re-clone).
+5. **Document the incident** in the team channel and (if SEV1/2) follow the incident response runbook.
+
+## Anti-patterns
+
+These all happen. Don't do them.
+
+- **Hardcoding a URL in a component** instead of reading from an env var. ESLint catches some of these, but not all.
+- **Committing a `.env.local` "just for now"** because you're tired and want to push. Always temporary, never reverted, eventually rotated under emergency conditions.
+- **Reading a secret from `import.meta.env` and assuming it's safe** because it doesn't have `VITE_` prefix. It's not — Vite excludes non-prefixed vars at build time, but if you ever rename it, the secret leaks.
+- **Putting backend credentials in the frontend** because "the backend will handle it." The frontend should never know the database password.
+- **Storing secrets in `localStorage`** to persist them across sessions. Use `httpOnly` cookies set by the backend, or don't persist them.
+- **Reusing the same secret across environments.** A leaked staging secret should not give an attacker production access.
+
+## Cross-references
+
+- `frontend/.env.example` — template for local dev
+- `frontend/.env.local.example` — example overrides
+- `frontend/.env.staging.example` — staging template
+- `frontend/.env.production.example` — production template
+- `frontend/scripts/check-env.mjs` — pre-flight validator
+- `skills/security.md` — broader security policy
+- `docs/runbooks/deployment-runbook.md` — references this doc for env setup
+- `CLAUDE.md` Section 6 — the one-line "no .env files committed" rule

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,46 @@
+# =============================================================================
+# .env.example — template for local environment variables
+# =============================================================================
+#
+# WARNING: Never commit a real .env file. Copy this to .env.local and fill in
+# the real values there. .env, .env.local, and .env.*.local are all gitignored.
+#
+# Vite-prefixed variables (VITE_*) are baked into the client bundle at build
+# time. Anyone who downloads your JS can read them. Use them ONLY for non-secret
+# values: API base URLs, public keys, feature flags. Real secrets stay on the
+# backend.
+#
+# When adding a new variable here:
+#   1. Add it to scripts/check-env.ts so the build fails fast if it's missing
+#   2. Document it in docs/environments.md
+#   3. Add an example value (NOT a real secret)
+#
+# See:
+#   - skills/security.md for the secrets policy
+#   - docs/environments.md for the per-environment strategy
+#   - docs/dependency-upgrades.md for related dep handling
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Required — backend API
+# -----------------------------------------------------------------------------
+
+# Backend API base URL. Public — OK to bake into the bundle.
+# Local default points at the local backend dev server.
 VITE_API_BASE_URL=http://localhost:3001/api
+
+# -----------------------------------------------------------------------------
+# Optional — observability and analytics (filled in once those tickets land)
+# -----------------------------------------------------------------------------
+
+# Sentry DSN. Public — designed to be exposed in client bundles.
+# Leave blank in development to disable Sentry.
+# VITE_SENTRY_DSN=
+
+# Sentry environment tag (development / staging / production).
+# Defaults to import.meta.env.MODE if unset.
+# VITE_SENTRY_ENVIRONMENT=development
+
+# Analytics provider key. Public — exposed in client bundles.
+# Leave blank to use the no-op analytics implementation.
+# VITE_ANALYTICS_WRITE_KEY=

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,19 @@
+# =============================================================================
+# .env.local.example — local development overrides
+# =============================================================================
+#
+# Copy this to .env.local and fill in. .env.local is gitignored and overrides
+# .env values.
+#
+# Use this for:
+#   - Pointing the frontend at a local backend you're running
+#   - Trying out a feature flag without touching the committed default
+#   - Testing against a staging API from your laptop
+#
+# Anything you put here is for YOUR machine only. Do not commit.
+# =============================================================================
+
+VITE_API_BASE_URL=http://localhost:3001/api
+
+# Uncomment to test feature flags locally
+# VITE_FLAG_EXAMPLE_NEW_DASHBOARD=true

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,0 +1,15 @@
+# =============================================================================
+# .env.production.example — production environment template
+# =============================================================================
+#
+# This file is a TEMPLATE. Real production values are set in the hosting
+# provider's secret manager — never committed.
+#
+# Copy this list when configuring production so you don't miss any required
+# variables.
+# =============================================================================
+
+VITE_API_BASE_URL=https://api.example.com/api
+VITE_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+VITE_SENTRY_ENVIRONMENT=production
+VITE_ANALYTICS_WRITE_KEY=<production-write-key>

--- a/frontend/.env.staging.example
+++ b/frontend/.env.staging.example
@@ -1,0 +1,15 @@
+# =============================================================================
+# .env.staging.example — staging environment template
+# =============================================================================
+#
+# This file is a TEMPLATE. Real staging values are set in the hosting
+# provider's secret manager (Vercel / Netlify / AWS / etc.) — never committed.
+#
+# Copy this list when configuring a new staging environment so you don't miss
+# any required variables.
+# =============================================================================
+
+VITE_API_BASE_URL=https://staging-api.example.com/api
+VITE_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+VITE_SENTRY_ENVIRONMENT=staging
+VITE_ANALYTICS_WRITE_KEY=<staging-write-key>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "npm run check-env && vite",
+    "build": "npm run check-env && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "check-env": "node scripts/check-env.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/frontend/scripts/check-env.mjs
+++ b/frontend/scripts/check-env.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Pre-flight environment variable check.
+ *
+ * Run before `vite dev` and `vite build`. Fails fast with a clear error
+ * message if any required variable is missing or obviously wrong.
+ *
+ * Usage:
+ *   node scripts/check-env.mjs
+ *
+ * To add a new required variable:
+ *   1. Add it to REQUIRED_VARS below with a description
+ *   2. Add it to .env.example with a comment
+ *   3. Document it in docs/environments.md
+ *
+ * To add a variable that's only required in production:
+ *   - Add it to PRODUCTION_REQUIRED_VARS instead
+ *
+ * This script is intentionally written as plain ESM JavaScript (not
+ * TypeScript) so it can run with `node` directly — no extra runtime
+ * dependency.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+
+// Best-effort: load .env.local then .env so we can validate the same way
+// Vite would. We don't depend on dotenv to avoid the install.
+function loadDotenv(filename) {
+  const path = join(projectRoot, filename);
+  if (!existsSync(path)) return;
+  const text = readFileSync(path, 'utf8');
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+loadDotenv('.env.local');
+loadDotenv('.env');
+
+const REQUIRED_VARS = [
+  {
+    name: 'VITE_API_BASE_URL',
+    description: 'Backend REST API base URL',
+    pattern: /^https?:\/\/.+/,
+  },
+];
+
+const PRODUCTION_REQUIRED_VARS = [
+  // Uncomment when ticket #32 (Sentry) lands:
+  // { name: 'VITE_SENTRY_DSN', description: 'Sentry DSN for error tracking' },
+];
+
+const env = process.env;
+const mode = env.NODE_ENV ?? env.VITE_MODE ?? 'development';
+const isProduction = mode === 'production';
+
+const errors = [];
+
+function checkVar(spec) {
+  const value = env[spec.name];
+  if (value === undefined || value === '') {
+    errors.push(`  ✗ ${spec.name} is required but not set — ${spec.description}`);
+    return;
+  }
+  if (spec.pattern && !spec.pattern.test(value)) {
+    errors.push(
+      `  ✗ ${spec.name} = "${value}" does not match expected format (${spec.pattern}) — ${spec.description}`,
+    );
+  }
+}
+
+REQUIRED_VARS.forEach(checkVar);
+if (isProduction) {
+  PRODUCTION_REQUIRED_VARS.forEach(checkVar);
+}
+
+if (errors.length > 0) {
+  process.stderr.write(`\n✗ Environment check failed (${mode} mode):\n\n`);
+  errors.forEach((line) => process.stderr.write(`${line}\n`));
+  process.stderr.write(
+    `\nFix the missing variables in your .env.local file (copy from .env.example to start),\n` +
+      `then re-run the command. See docs/environments.md for the full per-environment guide.\n\n`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(`✓ Environment check passed (${mode} mode)\n`);

--- a/skills/deployment.md
+++ b/skills/deployment.md
@@ -61,10 +61,14 @@ The CI pipeline runs on every push to a PR branch:
 7. Report results on the PR
 
 ## Environment Variables
-- Never commit `.env` files.
-- Use `.env.example` as the reference for required variables.
-- In CI/CD, set variables via GitHub Secrets.
-- In Docker, pass variables at runtime, not build time.
+
+> Full per-environment strategy, secret rotation process, and the variable catalog live in [`docs/environments.md`](../docs/environments.md). The bullets below are the always-on rules.
+
+- Never commit `.env` files. Only `.env.example`, `.env.local.example`, `.env.staging.example`, `.env.production.example` are in git.
+- The `frontend/scripts/check-env.mjs` script runs before `dev` and `build` and fails fast if a required variable is missing.
+- In CI/CD, set variables via GitHub Secrets and the hosting provider's secret manager. Real secrets never live in any committed file.
+- In Docker, pass variables at runtime, not build time. `VITE_*` variables are baked at build time, so they must be present during `npm run build` — but real secrets stay on the backend regardless.
+- Adding a new required variable means updating `check-env.mjs`, `.env.example`, the per-env example files, AND `docs/environments.md` in the same PR. See the doc for the full checklist.
 
 ## Rollback
 - Keep the previous deployment artifact available.


### PR DESCRIPTION
## Summary
- Rewrites `frontend/.env.example` with a documented header explaining the `VITE_*` exposure rules and structured required/optional sections.
- Adds per-environment templates: `.env.local.example`, `.env.staging.example`, `.env.production.example` — flat catalogs to copy into the hosting provider's secret manager.
- Adds `frontend/scripts/check-env.mjs` — pre-flight validator that runs before `vite dev` and `vite build`. Loads `.env.local` then `.env`, validates required vars, fails fast with a clear error. Plain ESM JS so no extra runtime dep needed.
- Wires the validator into `package.json`: `dev` and `build` now run `check-env` first.
- Adds `docs/environments.md` as the canonical per-environment reference: three-environment table, local setup, staging/production secret manager flow, how to add a new required variable in five steps, the variable catalog, secret rotation process, and a "what NEVER to commit" list.
- Updates `skills/deployment.md` to reference `docs/environments.md`.

## Test plan
- [x] `node scripts/check-env.mjs` with no env → fails with clear error pointing at `VITE_API_BASE_URL`
- [x] Same with `.env.local` copied from `.env.example` → passes
- [ ] After merge, the next time someone adds a new required env var, they follow the five-step checklist and the missing-var case is caught before merge

## Notes
- The build currently has a pre-existing TS error in `DateRangeFilter.test.tsx` because main lacks `@testing-library/jest-dom` typings setup. The fix is in PR #50 (feature flags) which adds the vitest test setup file. **This PR does not introduce that failure** — it exists on main today. Both PRs will work cleanly once feature flags merges.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)