### PR TITLE
Phase 9 — Production architecture v2.0 (#81–#94)

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,62 @@
+---
+description: "Second-Claude code review — review the diff as if you didn't write it"
+---
+
+You are acting as a **code reviewer**, NOT the author. You did NOT write this code. Your job is to find problems the author missed.
+
+**Step 1 — Get the diff:**
+```bash
+git diff main...HEAD
+```
+
+**Step 2 — Read the relevant skill files** for the areas the diff touches (frontend.md, api.md, security.md, accessibility.md, testing.md, etc.)
+
+**Step 3 — Review the diff line by line.** For every issue, use the prefix convention from `skills/code-review.md`:
+
+- `blocker:` — must fix before merge (real bug, security issue, missing test, broken a11y, type error)
+- `suggestion:` — would improve the code but not blocking
+- `question:` — genuinely unclear, needs explanation
+- `nit:` — minor style, not blocking
+
+**Check for:**
+
+### Correctness
+- Does the code do what the ticket asks?
+- Are edge cases handled (empty, null, error, very long input)?
+- Is there dead code or leftover debug code?
+
+### Tests
+- Are there tests for the new code?
+- Do tests cover loading / error / success / empty states?
+- Are tests testing behavior, not implementation details?
+
+### Security (per skills/security.md)
+- No hardcoded secrets, tokens, or API keys
+- No `dangerouslySetInnerHTML` without DOMPurify
+- No PII in logs, errors, analytics, or Sentry
+- User input sanitized before use in URLs
+
+### Accessibility (per skills/accessibility.md)
+- Every interactive element keyboard-reachable
+- Every form input has a `<label>`
+- No `<div onClick>` — use `<button>`
+- Color is not the only signal
+
+### Performance
+- Any new dependency added? Justified?
+- `useMemo` / `React.memo` used correctly (not everywhere)?
+- Code splitting for new routes?
+
+### Conventions
+- Matches existing patterns?
+- Naming correct?
+- Import order correct?
+
+**Step 4 — Output the review** as a numbered list of findings with prefixes.
+
+**Step 5 — Give a verdict:**
+- **APPROVE** — no blockers, ship it
+- **APPROVE WITH SUGGESTIONS** — no blockers, but suggestions worth considering
+- **CHANGES REQUESTED** — blockers found, list what needs to change
+
+If CHANGES REQUESTED, fix every blocker, then re-run the review.

--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -1,0 +1,38 @@
+---
+description: "Create a structured implementation plan before writing any code"
+---
+
+I need to plan a feature before implementing it. Help me create a plan using the annotation cycle workflow.
+
+**Steps:**
+
+1. **Ask me for the GitHub issue number.** Read the issue body with `gh issue view [NUMBER]`.
+
+2. **Read the relevant skill files** based on what the ticket touches:
+   - Frontend work → `skills/frontend.md`
+   - API work → `skills/api.md`
+   - Tests → `skills/testing.md`
+   - Database → `skills/database.md`
+   - Deployment → `skills/deployment.md`
+   - Security-sensitive → `skills/security.md`
+   - Accessibility-related → `skills/accessibility.md`
+
+3. **Copy the plan template** from `.claude/templates/plan-template.md` and fill in every section:
+   - Goal (one sentence)
+   - Context (why now, constraints)
+   - Proposed approach (files to create, files to modify, dependency order)
+   - Test plan (unit, integration, manual)
+   - Acceptance criteria (observable outcomes)
+   - Risks and open questions
+
+4. **Write the plan** to `plans/[issue-number]-[short-desc].md`.
+
+5. **Show me the plan** and ask for approval. Do NOT start coding until I say "approved" or "go".
+
+**Rules:**
+- The plan must be specific enough that a different developer could implement it without asking questions.
+- Every file listed must have a one-line description of what it does or what changes.
+- The test plan must cover loading, error, success, and empty states for any data-fetching component.
+- If the feature is large (>5 files), suggest splitting into sub-tickets.
+
+This follows the annotation cycle: **plan → approve → implement → review → merge**.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,22 +1,71 @@
 ---
-description: "Run self-review against CLAUDE.md and skill files before creating a PR"
+description: "3-pass self-review against CLAUDE.md and skill files before creating a PR"
 ---
 
-Review the code you just wrote against our CLAUDE.md standards and the relevant skill files.
+Run a structured 3-pass self-review of the code you just wrote. Each pass focuses on a different category so nothing gets missed.
 
-Check for:
-1. Coding standard violations (naming, imports, file structure)
-2. Missing test cases
-3. Hardcoded values (URLs, secrets, magic numbers)
-4. Security issues (exposed credentials, XSS, injection)
-5. Performance problems (unnecessary re-renders, missing memoization, large bundles)
-6. Accessibility issues (missing labels, keyboard navigation, contrast)
-7. TypeScript issues (any types, missing return types, loose typing)
-8. Console.log statements or debug code left in
-9. Unused imports or variables
-10. Error handling gaps (missing loading/error/empty states)
+---
 
-List every issue you find, then fix them all. After fixing, confirm the code passes:
-- npm run lint
-- npx tsc --noEmit
-- npm test
+## Pass 1: Standards Compliance
+
+Review against CLAUDE.md and the relevant skill files. Check for:
+
+1. **Naming** — camelCase vars/functions, PascalCase components/types, UPPER_SNAKE constants
+2. **Imports** — correct order (React → libs → internal → hooks → utils → types), no unused
+3. **File structure** — one component per file, under 150 lines, correct directory
+4. **TypeScript** — no `any`, explicit return types, `interface` for objects, `type` for unions
+5. **Tailwind** — no inline styles, no hardcoded hex, using the project's design tokens
+6. **Console** — no `console.log/info/warn/error` — use the structured `logger` instead
+7. **Hardcoded values** — no magic numbers, no hardcoded URLs, no secrets
+8. **Data fetching** — React Query, never `useEffect` + `fetch`
+
+**List every violation found, then fix them all.**
+
+---
+
+## Pass 2: Security Review
+
+Review against `skills/security.md`. Check for:
+
+1. **Auth tokens** — not stored in localStorage or sessionStorage
+2. **User input** — sanitized before rendering as HTML or inserting into URLs
+3. **XSS** — no `dangerouslySetInnerHTML` without DOMPurify
+4. **PII** — no emails, names, phone numbers, addresses in logs, errors, analytics, or Sentry
+5. **Secrets** — no API keys, tokens, or credentials in the code
+6. **Dependencies** — any new dependency justified and vetted? `npm audit` clean?
+7. **CORS / CSRF** — handled if the change touches API calls
+8. **Content-Type** — not hardcoded for non-JSON bodies
+
+**List every issue found, then fix them all.**
+
+---
+
+## Pass 3: Edge Cases & Accessibility
+
+Review against `skills/testing.md` and `skills/accessibility.md`. Check for:
+
+1. **Loading state** — every data-fetching component shows a skeleton
+2. **Error state** — friendly message + retry button, never raw error objects
+3. **Empty state** — helpful message when data is empty, not a blank page
+4. **Null / undefined** — does the code handle missing data gracefully?
+5. **Boundary values** — empty strings, zero, very long strings, special characters
+6. **Keyboard** — every interactive element reachable via Tab, focus visible
+7. **Labels** — every form input has an associated `<label>` with `htmlFor`
+8. **Semantic HTML** — `<button>` not `<div onClick>`, `<a>` for navigation
+9. **Color** — not the only signal for state (pair with icons or text)
+10. **Alt text** — every image has `alt` (or `alt=""` if decorative)
+
+**List every issue found, then fix them all.**
+
+---
+
+## After all 3 passes
+
+Confirm the code passes:
+```bash
+npm run lint
+npx tsc --noEmit
+npm test
+```
+
+Report: **"3-pass review complete. [N] issues found and fixed. All checks green."**

--- a/.claude/commands/staff-review-plan.md
+++ b/.claude/commands/staff-review-plan.md
@@ -1,0 +1,45 @@
+---
+description: "Second-Claude review of a plan before implementation begins"
+---
+
+You are acting as a **senior staff engineer reviewer**, NOT the author of this plan. Your job is to find problems, not to approve.
+
+**Read the plan file** the user specifies (or the most recent file in `plans/`).
+
+**Review against these criteria:**
+
+### 1. Completeness
+- Does every file listed have a clear purpose?
+- Are there files that will obviously need to change but aren't listed?
+- Is the dependency order between steps actually correct?
+- Are edge cases covered in the test plan (empty data, errors, auth failures, race conditions)?
+
+### 2. Scope
+- Does this plan do MORE than the ticket asks for? Flag scope creep.
+- Does this plan do LESS than the ticket asks for? Flag missing acceptance criteria.
+- Could this be split into smaller, independently shippable pieces?
+
+### 3. Architecture
+- Does the approach match existing patterns in the codebase? (Check the relevant skill files.)
+- Is there a simpler approach the author may have missed?
+- Are there performance implications (bundle size, render count, network calls)?
+- Does it introduce new dependencies? Are they justified?
+
+### 4. Security & Accessibility
+- Does the plan touch auth, user input, or external data? If so, does it reference `skills/security.md`?
+- Does the plan add UI? If so, does the test plan include accessibility checks?
+
+### 5. Risks
+- Are the "Risks & open questions" actually the real risks, or is the author being optimistic?
+- What's the worst thing that could happen if this plan is implemented as written?
+
+**Output format:**
+
+For each issue found, use the prefix convention from `skills/code-review.md`:
+- `blocker:` — must be fixed before approving the plan
+- `suggestion:` — would improve the plan but not blocking
+- `question:` — needs clarification before the reviewer can assess
+
+End with a clear verdict: **APPROVE**, **APPROVE WITH SUGGESTIONS**, or **REVISE NEEDED**.
+
+If REVISE NEEDED, list the specific changes required before re-review.

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# PreToolUse hook — blocks dangerous commands before execution.
+#
+# Registered in .claude/settings.json under hooks.PreToolUse.
+# Exit 2 = block the tool call. Exit 0 = allow it.
+#
+# What this blocks:
+#   - rm -rf / or rm -rf ~ (catastrophic deletes)
+#   - git push --force to main/master
+#   - git reset --hard on main/master
+#   - DROP TABLE / DROP DATABASE (accidental SQL)
+#   - chmod 777 (world-writable permissions)
+#   - Direct npm publish (should go through CI)
+
+set -euo pipefail
+
+# The tool input is passed via stdin as JSON.
+INPUT=$(cat)
+
+# Extract the command string from the tool input.
+COMMAND=$(echo "$INPUT" | grep -oP '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//' 2>/dev/null || echo "")
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# --- Dangerous patterns ---
+
+# Catastrophic rm
+if echo "$COMMAND" | grep -qE 'rm\s+-rf\s+(/|~|/home)'; then
+  echo "BLOCKED: rm -rf on root or home directory. This would delete everything." >&2
+  exit 2
+fi
+
+# Force push to main/master
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force.*\s+(main|master)'; then
+  echo "BLOCKED: force push to main/master. This rewrites shared history." >&2
+  exit 2
+fi
+if echo "$COMMAND" | grep -qE 'git\s+push\s+-f\s+.*\s+(main|master)'; then
+  echo "BLOCKED: force push to main/master. This rewrites shared history." >&2
+  exit 2
+fi
+
+# Hard reset on main
+if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard' && git branch --show-current 2>/dev/null | grep -qE '^(main|master)$'; then
+  echo "BLOCKED: git reset --hard on main/master. Switch to a feature branch first." >&2
+  exit 2
+fi
+
+# SQL drops
+if echo "$COMMAND" | grep -qiE '(DROP\s+TABLE|DROP\s+DATABASE)'; then
+  echo "BLOCKED: DROP TABLE/DATABASE detected. Use a migration instead." >&2
+  exit 2
+fi
+
+# chmod 777
+if echo "$COMMAND" | grep -qE 'chmod\s+777'; then
+  echo "BLOCKED: chmod 777 makes files world-writable. Use a more restrictive permission." >&2
+  exit 2
+fi
+
+# npm publish (should go through CI)
+if echo "$COMMAND" | grep -qE 'npm\s+publish'; then
+  echo "BLOCKED: npm publish should go through CI, not run manually." >&2
+  exit 2
+fi
+
+# If none matched, allow the command.
+exit 0

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# PostToolUse hook — auto-lints files after Edit or Write.
+#
+# Registered in .claude/settings.json under hooks.PostToolUse.
+# Runs after every successful Edit or Write tool call.
+# Exit code is informational only (doesn't block the tool).
+#
+# What this does:
+#   - Detects the file that was just edited/written
+#   - If it's a .ts/.tsx/.js/.jsx file, runs ESLint --fix on it
+#   - Reports any remaining unfixable issues so Claude can address them
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract file_path from the tool input JSON.
+FILE=$(echo "$INPUT" | grep -oP '"file_path"\s*:\s*"[^"]*"' | head -1 | sed 's/"file_path"\s*:\s*"//;s/"$//' 2>/dev/null || echo "")
+
+if [ -z "$FILE" ]; then
+  exit 0
+fi
+
+# Only lint JS/TS files.
+case "$FILE" in
+  *.ts|*.tsx|*.js|*.jsx)
+    # Find the nearest directory containing an eslint config.
+    DIR=$(dirname "$FILE")
+    while [ "$DIR" != "/" ] && [ "$DIR" != "." ]; do
+      if [ -f "$DIR/eslint.config.js" ] || [ -f "$DIR/.eslintrc.js" ] || [ -f "$DIR/.eslintrc.json" ]; then
+        cd "$DIR"
+        npx eslint --fix "$FILE" 2>&1 || true
+        exit 0
+      fi
+      DIR=$(dirname "$DIR")
+    done
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,28 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-dangerous.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/post-edit-lint.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/.claude/templates/plan-template.md
+++ b/.claude/templates/plan-template.md
@@ -1,0 +1,53 @@
+# Plan: [FEATURE_NAME]
+
+> **Issue:** #[NUMBER]
+> **Branch:** `feature/[NUMBER]-[short-desc]`
+> **Author:** [NAME]
+> **Status:** draft | approved | in-progress | completed
+
+## Goal
+
+[One sentence — what does the user get when this is done?]
+
+## Context
+
+[2-3 sentences — why is this needed now? Link to the ticket, any prior art, constraints.]
+
+## Proposed approach
+
+### Files to create
+- [ ] `path/to/file.tsx` — [what it does]
+
+### Files to modify
+- [ ] `path/to/existing.tsx` — [what changes and why]
+
+### Dependencies between steps
+1. [Step A] must happen before [Step B] because...
+2. ...
+
+## Test plan
+
+- [ ] Unit: [component] renders in loading/error/success/empty states
+- [ ] Unit: [util] handles edge cases (empty input, null, overflow)
+- [ ] Integration: [flow] works end-to-end with MSW mocks
+- [ ] Manual: [specific user action] → [expected result]
+
+## Acceptance criteria
+
+- [ ] [Observable outcome #1]
+- [ ] [Observable outcome #2]
+- [ ] All tests pass (`npm test`)
+- [ ] Lint clean (`npm run lint`)
+- [ ] Build succeeds (`npx vite build`)
+- [ ] Self-review completed (`/review`)
+
+## Risks & open questions
+
+- [Risk or question that might change the approach]
+- [Anything that needs PM/tech lead input before coding]
+
+## Annotation cycle
+
+> This plan follows the **annotation cycle**: write plan → get approval → implement → review → merge. Do NOT start coding until this plan is approved.
+
+**Approval:** [ ] Approved by [REVIEWER_NAME] on [DATE]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,18 +6,47 @@
 
 Closes #[issue number]
 
-## Checklist
+## AI Disclosure
 
-- [ ] Tests pass locally (`npm test`)
-- [ ] Coverage >= 80% (`npm run test:coverage`)
-- [ ] Lint passes (`npm run lint`)
-- [ ] Type check passes (`npx tsc --noEmit`)
-- [ ] Build succeeds (`npm run build`)
-- [ ] Claude self-review completed
-- [ ] No `console.log` in production code
-- [ ] No hardcoded URLs or secrets
+<!-- Required: disclose whether AI was used and for what -->
+- [ ] This code was **fully AI-generated** (Claude Code)
+- [ ] This code was **partially AI-assisted** — AI wrote [describe scope], human wrote [describe scope]
+- [ ] This code was **fully human-written**
+
+## Test plan
+
+- [ ] `npm test` green
+- [ ] `npm run lint` green
+- [ ] `npm run build` green
+- [ ] [Describe specific manual testing performed]
+
+## Author checklist
+
+- [ ] Branch and commit follow `skills/git-workflow.md` conventions
+- [ ] Tests cover the new code (>= 80% coverage)
+- [ ] 3-pass self-review completed (`/review`)
+- [ ] No `console.log` — use `logger` from `frontend/src/lib/logger.ts`
+- [ ] No hardcoded URLs or secrets (see `skills/security.md`)
 - [ ] No `any` types
+- [ ] No PII in logs, errors, analytics, or Sentry
+- [ ] Docs / ADRs updated if the change is non-trivial
+
+## Reviewer
+
+<!-- Name the specific person reviewing this PR -->
+**Assigned reviewer:** @[github-username]
+
+## Rollback plan
+
+<!-- What happens if this breaks production after merge? -->
+- [ ] **Revert is safe** — `git revert <sha>` with no data migration concerns
+- [ ] **Revert needs care** — [explain why, e.g., database migration, external API change]
+- [ ] **Feature flag** — can be turned off via `setFlagOverride('flag-name', false)` without redeploy
 
 ## Screenshots
 
-[If UI changes, include before/after screenshots]
+[For any UI change, include before/after screenshots]
+
+---
+
+> **Dependabot PRs** follow `docs/dependency-upgrades.md` instead of this checklist. CI must still be green.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+# gitleaks configuration — credential scanning for pre-commit and CI.
+# See skills/security.md for the full secrets policy.
+# Docs: https://github.com/gitleaks/gitleaks
+
+title = "Agent Space gitleaks config"
+
+[extend]
+# Use the default gitleaks rules as the base.
+useDefault = true
+
+[allowlist]
+# Files that are known to contain placeholder/example values, not real secrets.
+paths = [
+  '''\.env\.example$''',
+  '''\.env\.local\.example$''',
+  '''\.env\.staging\.example$''',
+  '''\.env\.production\.example$''',
+  '''docs/''',
+  '''skills/''',
+]

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,8 @@
+# Enforce conventional commit format.
+# Install: npm install -D @commitlint/cli @commitlint/config-conventional
+# If commitlint is not installed, skip with a warning.
+if command -v npx &> /dev/null && [ -f "commitlint.config.js" ]; then
+  npx --no-install commitlint --edit "$1" 2>/dev/null || {
+    echo "⚠️  commitlint not installed — skipping format check. Run: npm install -D @commitlint/cli @commitlint/config-conventional"
+  }
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,10 @@
 npx lint-staged
+
+# Credential scanning — blocks commits that contain secrets.
+# Install gitleaks: https://github.com/gitleaks/gitleaks#installing
+# If gitleaks is not installed, skip with a warning (don't block dev workflow).
+if command -v gitleaks &> /dev/null; then
+  gitleaks git --pre-commit --staged --config .gitleaks.toml
+else
+  echo "⚠️  gitleaks not installed — skipping credential scan. Install: https://github.com/gitleaks/gitleaks#installing"
+fi

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,28 @@
+/**
+ * Commitlint config — enforces Conventional Commits format.
+ *
+ * Format: {type}({scope}): {subject}
+ *
+ * Allowed types: feat, fix, docs, style, refactor, test, chore, perf, ci
+ * See skills/git-workflow.md for the full convention.
+ *
+ * The commit-msg hook in .husky/commit-msg runs this via commitlint.
+ * Install: npm install -D @commitlint/cli @commitlint/config-conventional
+ */
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Max 72 chars for subject line (matches git-workflow.md)
+    'header-max-length': [2, 'always', 72],
+    // Require a type
+    'type-empty': [2, 'never'],
+    // Require a subject
+    'subject-empty': [2, 'never'],
+    // Allowed types — matches skills/git-workflow.md
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'chore', 'perf', 'ci'],
+    ],
+  },
+};

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -89,6 +89,10 @@ After every coding task, before creating a PR, copy the self-review prompt from 
 
 Once comfortable with single-terminal Claude Code, read `docs/multi-terminal-workflow.md` to learn how to run 4 parallel sessions for approximately 4x productivity.
 
+## Step 9: Know the weekly audit
+
+Every Friday, one person runs a 30-minute quality audit — test coverage, dependency health, feature flag hygiene, runbook freshness, CI status, and a security spot-check. The process is documented in [`docs/weekly-audit.md`](./weekly-audit.md). You don't need to run it your first week, but know it exists so you can take a rotation slot when you're settled.
+
 ## Getting Help
 
 - **Stuck on a task?** Ask Claude first, then your PM.

--- a/docs/weekly-audit.md
+++ b/docs/weekly-audit.md
@@ -1,0 +1,95 @@
+# Weekly Audit Process
+
+> **Owner:** Rotating (currently Akshat)
+> **When:** Every Friday, 30 minutes
+> **Purpose:** Catch quality drift before it compounds. The template has 9+ quality gates on every PR, but gates only work if they're maintained.
+
+## Why a weekly audit
+
+Individual PRs are reviewed, but trends slip through:
+- Coverage creeps from 85% to 78% over 10 PRs, each individually "close enough"
+- A flag that was supposed to expire 3 months ago is still in the codebase
+- Dependabot PRs pile up because nobody owns the Monday review
+- The deploy runbook references a server that was decommissioned 2 weeks ago
+- An ADR is superseded but nobody wrote the replacement
+
+The weekly audit is 30 minutes of *"is the system still healthy?"* — not a line-by-line code review.
+
+## The checklist
+
+### 1. Test coverage (5 min)
+
+```bash
+cd frontend && npm run test:coverage
+```
+
+- [ ] Coverage is at or above **80%** for statements, branches, functions, lines
+- [ ] If below, open a ticket tagged `test-debt` for the specific files/functions that dropped
+- [ ] No test files were deleted without replacement in the last week's PRs
+
+### 2. Dependency health (5 min)
+
+```bash
+cd frontend && npm audit
+```
+
+- [ ] No **high** or **critical** CVEs. If any exist, escalate immediately — don't wait for Dependabot.
+- [ ] Check the [Dependabot PR queue](https://github.com/developer-agentspace/agentspace-dev-template/pulls?q=is:pr+is:open+label:dependencies). Are there PRs older than 7 days? If yes, review them now or assign someone.
+- [ ] No new dependency was added this week without justification in its PR description.
+
+### 3. Feature flag hygiene (3 min)
+
+Open `frontend/src/lib/flags-config.ts`:
+
+- [ ] Every flag has an `expiresOn` date
+- [ ] Any flag past its expiry gets one of: removed (if fully rolled out or abandoned), or re-justified with a new expiry
+- [ ] No flag has been at 100% rollout for more than 2 weeks without being cleaned up
+
+### 4. Runbook and doc freshness (5 min)
+
+- [ ] `docs/runbooks/deployment-runbook.md` — do the deploy commands still match reality? (Spot-check one command.)
+- [ ] `docs/runbooks/incident-response.md` — are the escalation contacts still correct?
+- [ ] `docs/environments.md` — does the variable catalog match what's actually in `.env.example`?
+- [ ] Were any ADRs written this week? If a significant decision was made without one, open a ticket.
+
+### 5. CI health (5 min)
+
+- [ ] Open the [Actions tab](https://github.com/developer-agentspace/agentspace-dev-template/actions). Are there failing workflows on `main`? If yes, that's a P0 — fix today.
+- [ ] Is the Lighthouse CI workflow still running? Check the last successful run date.
+- [ ] Is SonarQube reporting? Check the last scan.
+
+### 6. Security spot-check (5 min)
+
+```bash
+# If gitleaks is installed:
+gitleaks git --since="7 days ago" --config .gitleaks.toml
+```
+
+- [ ] No secrets committed in the last week's PRs
+- [ ] `.env.example` doesn't contain real values (grep for anything that looks like a real token)
+- [ ] No new `dangerouslySetInnerHTML` added without DOMPurify (grep the diff)
+
+### 7. PR queue hygiene (2 min)
+
+- [ ] Any open PRs older than 3 business days? Ping the reviewer.
+- [ ] Any PRs with unresolved `blocker:` comments? They shouldn't be sitting.
+
+## After the audit
+
+- Post a one-line summary in the team channel: *"Friday audit: all green"* or *"Friday audit: [N] items flagged — tickets opened: #X, #Y"*
+- If any items are flagged, open tickets immediately. Don't "remember to do it Monday."
+- The audit is done when the checklist is complete and any flagged items have tickets.
+
+## What this is NOT
+
+- **Not a code review.** PRs have their own review process.
+- **Not a performance review of people.** This checks the *system*, not individuals.
+- **Not optional when things are busy.** Especially not then. That's when drift happens fastest.
+
+## Cross-references
+
+- `skills/security.md` — the full security policy the audit checks against
+- `skills/code-review.md` — the per-PR review playbook
+- `docs/dependency-upgrades.md` — the Dependabot policy
+- `docs/environments.md` — the env var catalog
+- `frontend/src/lib/flags-config.ts` — the feature flag registry

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+storybook-static
+*.min.js
+package-lock.json

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "auto"
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "lint-staged": {
     "frontend/src/**/*.{ts,tsx}": [
       "bash -c 'cd frontend && npx eslint --fix'",
-      "bash -c 'cd frontend && npx tsc --noEmit'"
+      "bash -c 'cd frontend && npx tsc --noEmit'",
+      "bash -c 'cd frontend && npx vitest related --run'"
     ],
     "frontend/src/**/*.{js,jsx}": [
       "bash -c 'cd frontend && npx eslint --fix'"

--- a/skills/api.md
+++ b/skills/api.md
@@ -1,5 +1,8 @@
 # API Skill — Backend Integration Rules
 
+<!-- activation-triggers: when touching frontend/src/lib/api.ts, any file that imports from api.ts, or any React Query hook -->
+> **When to read this:** before writing or modifying any API call, fetch wrapper, or React Query hook.
+
 ## Purpose
 This skill defines how Claude Code should handle all API communication. Every API call in the project follows these patterns.
 

--- a/skills/database.md
+++ b/skills/database.md
@@ -1,5 +1,8 @@
 # Database Skill — PostgreSQL Conventions
 
+<!-- activation-triggers: when creating migrations, modifying schema files, writing raw SQL, or touching any database-related code -->
+> **When to read this:** before creating a migration, modifying a schema, or writing any database query.
+
 ## Purpose
 This skill defines database naming conventions, schema patterns, and query standards for all Agent Space projects.
 

--- a/skills/deployment.md
+++ b/skills/deployment.md
@@ -1,5 +1,8 @@
 # Deployment Skill — CI/CD and Release Process
 
+<!-- activation-triggers: when modifying Dockerfiles, CI workflows, env vars, or preparing a production deploy -->
+> **When to read this:** before modifying CI/CD, Docker configs, env vars, or doing a production deploy. For the actual deploy procedure, use `docs/runbooks/deployment-runbook.md`.
+
 ## Purpose
 This skill defines how code gets from a merged PR to production for all Agent Space projects.
 

--- a/skills/frontend.md
+++ b/skills/frontend.md
@@ -1,5 +1,8 @@
 # Frontend Skill — React 19 + TypeScript + Tailwind CSS v4
 
+<!-- activation-triggers: when touching any file in frontend/src/components/, frontend/src/pages/, frontend/src/App.tsx, or any .tsx file -->
+> **When to read this:** before creating or modifying any React component, page, hook, or CSS. If you're touching a `.tsx` file, you should have read this.
+
 ## Purpose
 This skill defines how Claude Code should write frontend code for any Agent Space project. Follow these rules for all React component work.
 

--- a/skills/testing.md
+++ b/skills/testing.md
@@ -1,5 +1,8 @@
 # Testing Skill — Standards and Rules
 
+<!-- activation-triggers: when creating or modifying any .test.ts, .test.tsx file, or files in e2e/, or when test coverage drops -->
+> **When to read this:** before writing, modifying, or reviewing any test file.
+
 ## Purpose
 This skill defines testing standards for all Agent Space projects. Testing rules are 100% fixed — they do not change between projects.
 


### PR DESCRIPTION
## Summary

All 14 Phase 9 tickets (production architecture v2.0) implemented:

| # | What |
|---|---|
| #81 | Plan template with annotation cycle workflow |
| #82 | `/plan-feature` slash command |
| #83 | `/staff-review-plan` — second-Claude plan review |
| #84 | `block-dangerous.sh` PreToolUse hook (blocks rm -rf /, force push main, DROP TABLE, etc.) |
| #85 | `post-edit-lint.sh` PostToolUse hook (auto eslint --fix after Edit/Write) |
| #86 | Prettier config + .prettierignore |
| #87 | gitleaks config + pre-commit credential scanning |
| #88 | Related tests in lint-staged via `vitest related --run` |
| #89 | `/review` restructured into 3-pass (standards, security, edge cases + a11y) |
| #90 | `/code-review` — second-Claude diff review with APPROVE/CHANGES REQUESTED verdict |
| #91 | PR template with AI disclosure, named reviewer, rollback plan |
| #92 | commit-msg hook + commitlint config for conventional commits |
| #93 | Activation triggers on all 5 core skill files |
| #94 | `docs/weekly-audit.md` — 7-section Friday checklist |

## Test plan
- [x] `npm test` → 6 passed
- [x] `npm run lint` → clean
- [x] `npx vite build` → green
- [x] Pre-commit hooks pass (gitleaks + commitlint skip gracefully when not installed)

Closes #81 #82 #83 #84 #85 #86 #87 #88 #89 #90 #91 #92 #93 #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)