### PR TITLE
Merge all missing content from PRs #47-#61 + fix coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,106 @@
+# Dependabot configuration for Agent Space dev template
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Policy summary (see docs/dependency-upgrades.md for the full playbook):
+# - Weekly schedule for npm + GitHub Actions
+# - Patch and minor updates grouped to reduce PR noise
+# - Dev dependencies grouped separately
+# - Major version bumps are ignored — handle manually with an ADR
+# - Security updates always run regardless of schedule
+# - Max 10 open PRs per ecosystem
+# - Auto-assign and label so the right reviewer is notified
+
+version: 2
+
+updates:
+  # ----- Root npm package (test runners, e2e, tooling) -----
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "P2"
+    assignees:
+      - "akshat-agentspace"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      production-minor-and-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-and-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Major bumps require manual evaluation + ADR — see docs/dependency-upgrades.md
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ----- Frontend npm package (React app) -----
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+      - "P2"
+    assignees:
+      - "akshat-agentspace"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      production-minor-and-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-and-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ----- GitHub Actions workflows -----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+      - "P2"
+    assignees:
+      - "akshat-agentspace"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,43 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        # Lighthouse runs against the static dist output, no dev server needed
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        run: npx --no-install lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+
+      - name: Upload Lighthouse report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report-${{ github.sha }}
+          path: frontend/.lighthouseci/
+          retention-days: 14

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,40 @@
+# {type}({scope}): {subject in present-tense imperative, max 72 chars}
+#
+# {Body — explain WHY this change exists, not WHAT it does. The diff
+# shows what. Wrap at 72 characters. Optional but encouraged for any
+# non-trivial change.}
+#
+# {Footer — close issues, mark breaking changes, refs to related PRs.}
+# Closes #
+#
+# ----------------------------------------------------------------------
+# Allowed types:
+#   feat     — new user-facing feature
+#   fix      — bug fix
+#   docs     — documentation only
+#   style    — formatting, missing semicolons, no code change
+#   refactor — code change that neither fixes a bug nor adds a feature
+#   test     — adding or fixing tests
+#   chore    — build, deps, tooling, config
+#   perf     — performance improvement
+#   ci       — CI/CD pipeline changes
+#
+# Scope is optional. Use a noun from the codebase: api, auth, search,
+# reports, etc.
+#
+# Subject rules:
+#   • imperative present tense ("add", not "added")
+#   • no trailing period
+#   • max 72 characters
+#
+# Examples:
+#   feat(search): add date range filter to shipping bills
+#   fix(auth): clear React Query cache on logout
+#   docs(adrs): record decision to use Tailwind over custom CSS
+#   chore(deps): bump react-query from 5.96 to 5.98 (patch group)
+#
+# Set this template as your commit editor for this repo with:
+#   git config --local commit.template .gitmessage
+#
+# See skills/git-workflow.md for the full convention.
+# ----------------------------------------------------------------------

--- a/docs/adrs/000-template.md
+++ b/docs/adrs/000-template.md
@@ -1,0 +1,54 @@
+# NNN — [Short noun phrase, e.g., "Use Postgres JSONB for flexible customer fields"]
+
+- **Status:** proposed | accepted | deprecated | superseded by NNN
+- **Date:** YYYY-MM-DD
+- **Deciders:** [names of people who agreed to this decision]
+
+## Context
+
+What is the issue we're facing? What constraints or pressures are driving the need for a decision? Two or three short paragraphs. Be specific — link to tickets, incidents, or external constraints.
+
+## Options considered
+
+### Option A — [Name]
+- **Pros:** [bullet points]
+- **Cons:** [bullet points]
+
+### Option B — [Name]
+- **Pros:** [bullet points]
+- **Cons:** [bullet points]
+
+### Option C — [Name]
+- **Pros:** [bullet points]
+- **Cons:** [bullet points]
+
+(Add or remove options as needed. If only one option was seriously considered, say so and explain why others were ruled out before evaluation.)
+
+## Decision
+
+We chose **Option [letter] — [name]**.
+
+Explain the reasoning in 2–4 sentences. Reference the specific tradeoffs from the Options section that drove the call. If the decision was contested, note who disagreed and why.
+
+## Consequences
+
+### What becomes easier
+- [bullet points]
+
+### What becomes harder
+- [bullet points]
+
+### What we'll need to revisit
+- [conditions under which we'd reopen this decision, e.g., "if request volume exceeds 10k/sec, the JSONB approach will need a rewrite"]
+
+## References
+
+- Ticket: [link]
+- PR: [link]
+- Discussion: [link to Slack thread, doc, or meeting notes]
+- Related ADRs: [list]
+- External: [docs, blog posts, RFCs that informed the decision]
+
+---
+
+> **Note for ADR authors:** Once this ADR is `accepted`, do not edit the Context, Options, or Decision sections. They are the historical record. The Consequences section may be appended with later observations, prefixed with a date.

--- a/docs/adrs/001-use-react-18-with-typescript.md
+++ b/docs/adrs/001-use-react-18-with-typescript.md
@@ -1,0 +1,58 @@
+# 001 — Use React 18 with TypeScript (strict mode)
+
+- **Status:** accepted
+- **Date:** 2026-04-08
+- **Deciders:** Tanay, Chinmay
+
+## Context
+
+Every project we build at Agent Space is a customer-facing dashboard or internal tool with rich interactivity (filters, charts, tables, forms). We needed to pick a single frontend stack so that the dev template, the team's skills, and Claude Code's instructions could all converge on one set of patterns. Having one stack means cross-project review, shared components, and onboarding are all cheaper.
+
+The team has prior production experience with React and Vue. Tanay has shipped React apps for the last four years; Chinmay's Power Apps work also leans on JavaScript/TypeScript. No one on the team has Svelte or Solid experience.
+
+## Options considered
+
+### Option A — React 18 + TypeScript (strict)
+- **Pros:** Largest ecosystem; strongest hiring pool in India; TypeScript catches whole classes of bugs at compile time; React 18 concurrent rendering helps with the chart-heavy dashboards we build; matches the team's existing skill set.
+- **Cons:** Larger bundle than Svelte/Solid; React 19 was on the horizon (now released and adopted in newer template versions); strict mode discipline takes effort to maintain.
+
+### Option B — Vue 3 + TypeScript
+- **Pros:** Single-file components are arguably cleaner; smaller learning curve for new devs; good TS support since Vue 3.
+- **Cons:** Smaller ecosystem in our specific niche (admin dashboards); fewer ready-made charting libraries with Vue bindings; team's React experience would be wasted; harder to find Vue devs in India.
+
+### Option C — Svelte + TypeScript
+- **Pros:** Smallest bundle; best DX for greenfield projects; compile-time reactivity is elegant.
+- **Cons:** Ecosystem is thin for enterprise dashboards; no team experience; higher hiring risk; charting libraries are immature; Claude Code has weaker training data on Svelte than React.
+
+### Option D — Plain JavaScript (no TypeScript)
+- **Pros:** Lower barrier; no build complexity for types.
+- **Cons:** Customer dashboards have data shape rules that *must* be enforced; without types, bugs ship to production. Ruled out at the outset.
+
+## Decision
+
+We chose **Option A — React 18 + TypeScript with strict mode**.
+
+The deciding factors were team skill alignment (React experience compounds across projects), ecosystem maturity (Recharts, React Query, React Hook Form, React Testing Library, MSW are all best-in-class), and the fact that Claude Code performs measurably better on React+TS than on alternatives. Strict mode is non-negotiable — half the value of TypeScript disappears without it.
+
+## Consequences
+
+### What becomes easier
+- Cross-project component reuse (KPICard, DataTable, ChartCard live in the template)
+- Hiring — large pool of React+TS engineers
+- Refactors are safer because the type checker catches breakage early
+- Claude Code generates better code on first try
+
+### What becomes harder
+- Bundle size requires active management (code splitting, lazy loading)
+- Strict mode requires discipline; `any` is forbidden by `CLAUDE.md` Section 6
+- React 18 → 19 migration will eventually need its own ADR
+
+### What we'll need to revisit
+- If a project specifically needs SSR-first or sub-100KB bundles, React may not be the right fit and we'd reopen this decision.
+- React 19 adoption will trigger a successor ADR.
+
+## References
+
+- CLAUDE.md Section 2 (Tech Stack)
+- skills/frontend.md
+- React 18 release notes: https://react.dev/blog/2022/03/29/react-v18

--- a/docs/adrs/002-tailwind-over-custom-css.md
+++ b/docs/adrs/002-tailwind-over-custom-css.md
@@ -1,0 +1,64 @@
+# 002 — Tailwind CSS over custom CSS files
+
+- **Status:** accepted
+- **Date:** 2026-04-08
+- **Deciders:** Tanay, Chinmay
+
+## Context
+
+Every project we ship has the same frontend problem: a designer (Tanay) hands over an HTML/Figma mockup, and a developer (or Claude) needs to translate it into reusable components without spending half the budget on CSS plumbing. Custom CSS at past gigs led to bloated stylesheets, naming conflicts, dead rules nobody could safely delete, and `!important` wars during the final QA crunch.
+
+We needed a styling approach that:
+
+1. Lets a developer match a Figma design without inventing a class hierarchy
+2. Stays in the JSX/TSX file so reviewers can see styling and structure together
+3. Doesn't allow specificity to grow over time
+4. Works well with Claude Code's pattern-matching strengths
+
+## Options considered
+
+### Option A — Tailwind CSS (utility-first)
+- **Pros:** No naming required; co-located with markup; PurgeCSS removes unused utilities so production CSS stays small; design tokens (colors, spacing, fonts) live in one config; Claude Code has very strong training data; easy to enforce consistency by listing allowed classes.
+- **Cons:** Long `className` strings can hurt readability for complex components; learning curve for devs who haven't seen utility-first; designer–developer handoff still requires translation from Figma values to Tailwind tokens.
+
+### Option B — CSS Modules
+- **Pros:** Real CSS, no new syntax; class names are scoped automatically; works with any CSS preprocessor.
+- **Cons:** Still requires inventing names for every visual variant; styling lives in a separate file from the component, so reviewers context-switch; design token enforcement is manual.
+
+### Option C — CSS-in-JS (styled-components, Emotion)
+- **Pros:** Co-located with components; full power of JS for dynamic styles; theme support is first-class.
+- **Cons:** Runtime cost (bundle + parse + style injection); React Server Components story is messy; team has had pain with this in past projects; the React team itself has discouraged it for new code.
+
+### Option D — Plain CSS files with BEM or similar
+- **Pros:** Familiar to everyone; no build chain.
+- **Cons:** Naming discipline always slips; dead code accumulates; the exact pattern we wanted to escape.
+
+## Decision
+
+We chose **Option A — Tailwind CSS**.
+
+Co-location with JSX (developer can see structure + styling in one file) and the absence of naming overhead were the deciding factors. The "long className strings" concern is real but mitigated by extracting components when a class string starts to feel oppressive — that's the right pressure release valve. Tailwind's PurgeCSS keeps shipped CSS small, and the team has standardized on `tailwind-merge` + `clsx` for conditional classes.
+
+## Consequences
+
+### What becomes easier
+- Pixel-matching a Figma design without inventing classes
+- Code review (everything is in the component file)
+- Removing dead styles (deleting a component deletes its styles)
+- Enforcing the design system (the `tailwind.config.js` / `@theme` block is the single source of truth for colors, spacing, fonts)
+
+### What becomes harder
+- Onboarding a developer who has never used Tailwind
+- Reading components with very long `className` strings — extract sub-components when this happens
+- Switching design systems mid-project (a token rename touches many files)
+
+### What we'll need to revisit
+- If we adopt React Server Components heavily, we may need to revisit the styling approach (Tailwind v4 already handles this well so this is unlikely).
+- If a client requires shipping a specific design system that's already coded against another solution (e.g., MUI), we'd write a per-project ADR overriding this one.
+
+## References
+
+- ADR 001 — Use React 18 with TypeScript
+- CLAUDE.md Section 6 (no inline styles)
+- skills/frontend.md (Tailwind CSS Rules section)
+- Tailwind v4 release notes: https://tailwindcss.com/blog/tailwindcss-v4

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,82 @@
+# Architecture Decision Records
+
+This directory holds the **Architecture Decision Records (ADRs)** for projects cloned from the Agent Space dev template. ADRs capture the *why* behind significant technical decisions so future developers (and future-you) don't have to guess or play archaeology with git history.
+
+## What is an ADR?
+
+An ADR is a short markdown document that records:
+
+1. **The context** — what was the problem or pressure that forced a decision?
+2. **The options** — what alternatives were considered, and what were their tradeoffs?
+3. **The decision** — what we picked and why.
+4. **The consequences** — what becomes easier and harder because of the choice.
+
+That's it. ADRs are not design documents, technical specs, or implementation guides. They are a paper trail for decisions, written at the moment of the decision, and never deleted.
+
+The format used here is based on Michael Nygard's original [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) post (2011), with minor adaptations for our process.
+
+## When to write one
+
+**Write an ADR when the decision:**
+
+- Affects the project structure (folder layout, module boundaries, build system)
+- Adds, removes, or replaces a major dependency (frameworks, runtimes, databases)
+- Locks in a pattern that other code will follow (state management, data fetching, error handling)
+- Has a cost that's hard to reverse (database schema, API contracts, auth model)
+- Was contested or had a non-obvious tradeoff that future devs will question
+
+**Do NOT write an ADR for:**
+
+- Implementation details inside a single file or function
+- Naming choices that don't affect external APIs
+- Dependency *upgrades* (those are tracked in PR descriptions; see `docs/dependency-upgrades.md`)
+- Trivial choices that can be reversed in a single PR without breaking other code
+
+If you're unsure, the test is: *"In six months, will a new developer ask why we did this?"* If yes, write an ADR. If no, skip it.
+
+## Numbering
+
+ADRs are numbered sequentially starting at `001`. **Numbers are never reused.** If an ADR is superseded, the number stays — the file gets a new status and a link to the replacement.
+
+File naming: `NNN-short-kebab-case-title.md`
+
+Examples:
+- `001-use-react-18-with-typescript.md`
+- `002-tailwind-over-custom-css.md`
+- `015-postgres-jsonb-for-flexible-customer-fields.md`
+
+## Status lifecycle
+
+Every ADR has a `Status` field at the top. The valid values are:
+
+| Status | Meaning |
+|---|---|
+| `proposed` | Drafted but not yet agreed. Open for comment. |
+| `accepted` | Decision is in effect. Code should follow it. |
+| `deprecated` | No longer recommended, but no replacement yet. |
+| `superseded by NNN` | Replaced by ADR number NNN. The newer ADR explains why. |
+
+Once accepted, **never edit the Context, Options, or Decision sections** — those are the historical record. If the situation changes, write a new ADR that supersedes the old one.
+
+You *may* edit the `Consequences` section to add observations as they emerge ("update 2026-08-01: this caused issue X, mitigated by Y").
+
+## How to write a new ADR
+
+1. Pick the next free number by counting the highest existing file in this directory and adding 1.
+2. Copy `000-template.md` to `NNN-your-title.md`.
+3. Fill in every section. If a section doesn't apply, write *"N/A — explain why"* rather than leaving it blank.
+4. Keep it short. **Target 200–500 words.** ADRs are not essays.
+5. Open a PR with the new ADR. Reviewers focus on whether the *decision* is sound, not whether the prose is polished.
+6. When merged, the ADR is canon. Code reviewers may cite it in future PRs.
+
+## Reading order for new developers
+
+If you're joining a project mid-way, read every ADR in this directory in numerical order before touching the codebase. They are the shortest path to understanding why the project looks the way it does. After you've read them, ask the team about any decisions that weren't recorded — those are the ones most likely to bite you.
+
+## Cross-references
+
+- **Template:** [`000-template.md`](./000-template.md)
+- **Architecture overview:** [`../architecture.md`](../architecture.md) — describes the *current* state, while ADRs describe how we got there.
+- **Dependency upgrades:** [`../dependency-upgrades.md`](../dependency-upgrades.md) — major upgrades require an ADR per the playbook.
+- **Original ADR post:** [Michael Nygard, 2011](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- **More examples:** [adr.github.io](https://adr.github.io)

--- a/docs/dependency-upgrades.md
+++ b/docs/dependency-upgrades.md
@@ -1,0 +1,127 @@
+# Dependency Upgrade Playbook
+
+This document is the source of truth for how the team handles dependency updates in any repo cloned from `agentspace-dev-template`. Pair this with `.github/dependabot.yml` (the config) and `skills/security.md` (the vulnerability response policy).
+
+## Why we automate this
+
+Dependencies rot. CVEs get filed against versions we ship. If we don't pay down upgrade debt continuously, we end up doing dangerous big-bang upgrades under deadline pressure, usually right after a security disclosure. Dependabot automates the boring weekly part so the only decisions left for humans are the ones that need judgment.
+
+## What Dependabot does for us
+
+`.github/dependabot.yml` configures three update streams:
+
+1. **Root npm** — test runners, e2e tooling, anything in the top-level `package.json`.
+2. **Frontend npm** — the React app under `/frontend`.
+3. **GitHub Actions** — pinned action versions in `.github/workflows/*.yml`.
+
+All three:
+
+- Run **weekly on Monday at 06:00 IST** so PRs are waiting when the team starts the week.
+- **Group minor + patch updates** by dependency type (production vs development) to cut PR noise.
+- **Ignore major version bumps** — those require manual evaluation and an ADR (see below).
+- **Auto-label** PRs with `dependencies` (and `frontend` / `ci` where relevant).
+- **Auto-assign** to the rotating reviewer (currently Akshat — change in `dependabot.yml` if it rotates).
+- **Cap open PRs** at 10 per ecosystem so the queue can't explode.
+
+Security updates run **out of band** — Dependabot ignores the schedule for them and opens PRs immediately when a CVE is published against a dependency we use. These bypass the major-version ignore rule too.
+
+## Weekly review process
+
+**Owner:** Akshat (rotating, see `.github/dependabot.yml` `assignees`)
+**When:** Every Monday afternoon, 30 min slot
+**SLA:** All non-major Dependabot PRs from that week are merged or have a written reason to defer by Friday EOD.
+
+**Steps for the reviewer:**
+
+1. Open `https://github.com/<org>/<repo>/pulls?q=is:pr+is:open+label:dependencies`.
+2. For each grouped PR, check the description (Dependabot lists every package in the group with old → new versions and changelog links).
+3. Wait for CI: lint, type check, tests, build, SonarQube must all be green.
+4. Apply the rules in the next section.
+5. Merge with **squash + delete branch**.
+6. If anything is deferred, comment on the PR with the reason and add the `blocked` label.
+
+## Update rules by type
+
+### Patch updates (`x.y.Z` → `x.y.Z+1`)
+
+- **Default:** auto-merge if CI is green.
+- **Why:** Patch releases are bug and security fixes. The semver contract says no API changes.
+- **Watch out for:** any patch in a package that has a history of breaking semver (lookin' at you, certain webpack plugins). When in doubt, smoke test locally.
+
+### Minor updates (`x.Y.z` → `x.Y+1.0`)
+
+- **Manual review.** Read the changelog. Run the app locally. Click around the affected feature.
+- **Smoke test checklist:**
+  - `npm run dev` boots without warnings
+  - `npm run build` succeeds
+  - `npm test` passes
+  - The feature touched by the package still works visually (if it's a UI library)
+- Merge if all green.
+
+### Major updates (`X.y.z` → `X+1.0.0`)
+
+- **Dependabot does not open these automatically** (we ignore them in the config). They have to be triggered manually.
+- **Process:**
+  1. Open an Architecture Decision Record (ADR) — see `docs/adr/` (when ticket #45 lands).
+  2. Read the migration guide cover to cover.
+  3. Create a `chore/upgrade-<package>-vX` branch.
+  4. Run the upgrade locally. Fix breakages. Update tests.
+  5. Open a PR. Tag Chinmay or Tanay for review.
+  6. Merge only after manual QA on a deployed preview.
+- **Estimated cost:** Always more than you think. Budget half a day minimum, even for "small" majors.
+
+### Security patches
+
+- **SLA: merged within 48 hours of the PR being opened.**
+- **Why:** A security update PR means GitHub knows about a vulnerability in a package we ship. The clock is ticking on disclosure timelines.
+- **Process:**
+  1. Reviewer is paged via the standard `dependencies` label notification PLUS a security advisory notification.
+  2. Drop other Dependabot work, prioritize this PR.
+  3. If CI passes, merge same day.
+  4. If CI fails because the patched version has a breaking change, escalate to Chinmay immediately — we'll do an emergency major upgrade and push a hotfix.
+  5. Document the incident in `docs/incidents/` (when ticket #44 lands).
+
+## Handling breaking changes
+
+Sometimes a "minor" update is technically a breaking change because the maintainer didn't follow semver. Or a security patch only exists in a major version we haven't migrated to yet.
+
+- **When to pin:** if a breaking minor update lands and we genuinely can't fix it this week, pin the package to the last good version in `package.json` (e.g., `"some-pkg": "1.4.2"` instead of `"^1.4.2"`) and open a follow-up ticket. Comment on the Dependabot PR with the ticket link and close it.
+- **When to upgrade:** if the breaking change is small (a renamed export, a removed deprecated API), just fix it in the same PR. Don't defer trivial migrations.
+- **When to swap:** if a package has gone unmaintained or hostile, this is the trigger to evaluate replacements. Open an ADR.
+
+## Lock file hygiene
+
+- **Never edit `package-lock.json` by hand.** It's generated. Hand-edits get overwritten on the next `npm install` and frequently break the dep tree.
+- **Always commit `package-lock.json`.** It's not optional — reproducible builds depend on it.
+- **One package change per commit.** When manually upgrading something, run `npm install <pkg>@<version>` and commit only the `package.json` and `package-lock.json` changes for that package. Don't mix multiple package upgrades into one commit.
+- **Never run `npm install` with no arguments to "refresh" the lock file.** That can silently bump every transitive dep. If you need to regenerate, delete `node_modules` and `package-lock.json` and reinstall, then carefully review the diff.
+
+## Adding new dependencies
+
+This is the inverse of upgrading and the same rules apply. Before adding any new package:
+
+1. **Justify it.** Is there a stdlib or existing dep that does this? Three lines of inline code is almost always better than a 50KB transitive dep tree.
+2. **Check the package on `npmjs.com`.** Last publish date, weekly downloads, open issue count, who maintains it.
+3. **Run `npm audit` after install** and fix anything it flags before committing.
+4. **Mention the addition in the PR description** — what package, why, what alternative was considered.
+5. **Avoid blacklisted packages:** see `CLAUDE.md` Section 6 (no Axios, no Redux, no Zustand, no MobX).
+
+## When Dependabot itself breaks
+
+Sometimes Dependabot opens nonsense PRs (wrong group, dep doesn't exist, etc.). To debug:
+
+1. Check the Dependabot logs: `https://github.com/<org>/<repo>/network/updates`
+2. Validate `dependabot.yml` syntax: GitHub will surface errors in the same UI.
+3. Common gotchas:
+   - `directory:` must point to a folder containing a `package.json`, not the `package.json` itself.
+   - Time format must be 24-hour `HH:MM`.
+   - Group names can't contain spaces or special characters.
+4. Fix `dependabot.yml`, commit, push. Dependabot picks it up within minutes.
+
+## Cross-references
+
+- **Config file:** `.github/dependabot.yml`
+- **Security policy:** `skills/security.md` (when ticket #33 lands) — for the vulnerability response flow
+- **ADR template:** `docs/adr/` (when ticket #45 lands) — for major upgrades
+- **Incident runbook:** `docs/incidents/` (when ticket #44 lands) — for security upgrade incidents
+- **GitHub Dependabot docs:** https://docs.github.com/en/code-security/dependabot

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,162 @@
+# Environment Management
+
+This document covers how environment variables and secrets are managed across local, staging, and production for any project cloned from `agentspace-dev-template`. Read it once before configuring a new environment, then reference it when adding a new env var.
+
+For the security policy on what can and can't be exposed in client bundles, see [`skills/security.md`](../skills/security.md). For the secrets policy specifically, this document is the canonical reference.
+
+## The three environments
+
+| Environment | Where it runs | Source of vars | Bundle exposure |
+|---|---|---|---|
+| **local** | A developer's laptop, `npm run dev` | `frontend/.env.local` (gitignored) | Same as production — anything `VITE_*` is in the JS bundle |
+| **staging** | Hosting provider's staging deployment, auto-deployed from `develop` if used | Hosting provider secret manager | Same |
+| **production** | Hosting provider's production deployment, deployed from `main` | Hosting provider secret manager | Same |
+
+The most important rule: **`VITE_*`-prefixed variables are baked into the client JavaScript bundle at build time**. Anyone who downloads the JS can read them. They are public. Use `VITE_*` only for non-secret values: API base URLs, public DSNs (Sentry), public write keys (some analytics providers), and feature flag flags.
+
+**Real secrets** (database credentials, server-side API keys, signing keys) **never go in `VITE_*` variables.** They live on the backend and are accessed via authenticated API calls.
+
+## Local development setup
+
+When you clone the repo for the first time:
+
+```bash
+cd frontend
+cp .env.example .env.local
+# Open .env.local in your editor and fill in any blank values your local
+# backend needs.
+```
+
+`.env.local` is gitignored. Vite reads it automatically when you run `npm run dev`. The `check-env` script (see below) runs first and fails fast if anything required is missing.
+
+### Why `.env.local` and not `.env`?
+
+Because Vite's load order is `.env.local` > `.env`. We commit `.env.example` (the template) and `.gitignore` everything else. `.env.local` is the conventional place for per-developer overrides — your colleague's `.env.local` doesn't have to look like yours.
+
+## Staging and production setup
+
+Real staging and production secrets are **not** stored in any file in the repo. They live in the hosting provider's secret manager:
+
+- **Vercel:** Project Settings → Environment Variables, scoped to "Preview" or "Production"
+- **Netlify:** Site Settings → Environment Variables
+- **AWS Amplify:** Environment Variables in the app settings
+- **Cloud Run / GKE:** Cloud Secret Manager + Workload Identity
+- **Self-hosted:** systemd `EnvironmentFile=` or a sealed-secrets manifest
+
+The repo contains `frontend/.env.staging.example` and `frontend/.env.production.example` as **templates** — flat lists of every variable that environment needs. When you set up a new staging or production environment, copy that list into the secret manager so you don't miss any variables.
+
+## The `check-env` script
+
+`frontend/scripts/check-env.mjs` runs before `npm run dev` and `npm run build`. It validates that every required environment variable is:
+
+1. Set
+2. Non-empty
+3. Matching its expected format (URLs are checked for `https?://` prefix)
+
+If any check fails, the script prints a clear error and exits non-zero, blocking the dev server or the build. The error tells you exactly which variable is missing and why it's needed.
+
+### Adding a new required variable
+
+When you add a new `VITE_*` variable to the codebase:
+
+1. **Add it to `frontend/scripts/check-env.mjs`** in the `REQUIRED_VARS` array (or `PRODUCTION_REQUIRED_VARS` if it's only required in production):
+
+   ```js
+   {
+     name: 'VITE_FEATURE_X_ENDPOINT',
+     description: 'Endpoint for feature X — see docs/environments.md',
+     pattern: /^https?:\/\/.+/,
+   }
+   ```
+
+2. **Add it to `frontend/.env.example`** with a comment explaining what it's for and an example value (NOT a real secret).
+
+3. **Add it to `frontend/.env.staging.example` and `.env.production.example`** so future environment setups don't miss it.
+
+4. **Document it in this file** (next section) under the appropriate category.
+
+5. **Set it in every existing environment** (your local `.env.local`, the staging secret manager, the production secret manager) **before** merging the PR. A PR that adds a required variable but doesn't set it in production will break the deploy.
+
+## Variable catalog
+
+This is the source of truth for what every variable does. Keep it in sync with `.env.example`.
+
+### Required (all environments)
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `VITE_API_BASE_URL` | Backend REST API base URL. The `apiClient` in `frontend/src/lib/api.ts` prepends this to every request. | `https://api.example.com/api` |
+
+### Optional (added per ticket)
+
+| Variable | Purpose | Required when |
+|---|---|---|
+| `VITE_SENTRY_DSN` | Sentry DSN for client error reporting. Public — designed to be exposed in bundles. | Ticket #32 (Sentry) merged |
+| `VITE_SENTRY_ENVIRONMENT` | Tag added to all Sentry events. Defaults to `import.meta.env.MODE` if unset. | Ticket #32 merged |
+| `VITE_ANALYTICS_WRITE_KEY` | Public write key for the analytics provider. Leave blank to use the no-op implementation. | Ticket #40 (analytics) merged |
+| `VITE_FLAG_<NAME>` | Per-flag override for the feature flag system. See `frontend/src/lib/flags-config.ts`. | Per flag |
+
+## Secret rotation
+
+Secrets need to be rotated regularly. The cadence depends on the secret type:
+
+| Secret type | Rotation cadence | Triggered by |
+|---|---|---|
+| Backend API tokens | Every 90 days | Calendar reminder + cron alert |
+| Sentry auth tokens | Every 180 days | Calendar reminder |
+| Analytics write keys | Every 180 days | Calendar reminder |
+| Anything that has been exposed | Immediately | Incident |
+
+### Rotation process
+
+1. **Generate the new secret** in the upstream service (Sentry dashboard, analytics provider, etc.).
+2. **Add the new secret to the staging environment** in the secret manager. Do not delete the old one yet.
+3. **Trigger a staging deploy** so the new secret is in use.
+4. **Verify staging works** with the new secret (smoke test the affected feature).
+5. **Repeat steps 2-4 for production.**
+6. **Wait 24 hours** to make sure no old code paths are still using the old secret.
+7. **Revoke the old secret** in the upstream service.
+
+Document the rotation in the team channel: which secret, when, who did it. This is your audit trail.
+
+## What NEVER to commit
+
+This list is enforced by `.gitignore` (see [`skills/security.md`](../skills/security.md) for the full pattern list):
+
+- `.env`
+- `.env.local`
+- `.env.development`, `.env.staging`, `.env.production` (real values — only `.example` files are committed)
+- `.env.*.local`
+- `*.pem`, `*.key`, `*.crt`, `*.p12`
+- `secrets/`
+- Any file containing the literal string of a real API key, token, password, or DSN
+
+If a secret is committed by accident:
+
+1. **Treat it as compromised immediately.** It's now in git history, on every clone, in any forks, and possibly in GitHub's caches.
+2. **Rotate the secret right now** in the upstream service.
+3. **Purge from history** with `git filter-repo` (NOT `git rm` — that doesn't touch history).
+4. **Force-push** the cleaned history (with team coordination — everyone needs to re-clone).
+5. **Document the incident** in the team channel and (if SEV1/2) follow the incident response runbook.
+
+## Anti-patterns
+
+These all happen. Don't do them.
+
+- **Hardcoding a URL in a component** instead of reading from an env var. ESLint catches some of these, but not all.
+- **Committing a `.env.local` "just for now"** because you're tired and want to push. Always temporary, never reverted, eventually rotated under emergency conditions.
+- **Reading a secret from `import.meta.env` and assuming it's safe** because it doesn't have `VITE_` prefix. It's not — Vite excludes non-prefixed vars at build time, but if you ever rename it, the secret leaks.
+- **Putting backend credentials in the frontend** because "the backend will handle it." The frontend should never know the database password.
+- **Storing secrets in `localStorage`** to persist them across sessions. Use `httpOnly` cookies set by the backend, or don't persist them.
+- **Reusing the same secret across environments.** A leaked staging secret should not give an attacker production access.
+
+## Cross-references
+
+- `frontend/.env.example` — template for local dev
+- `frontend/.env.local.example` — example overrides
+- `frontend/.env.staging.example` — staging template
+- `frontend/.env.production.example` — production template
+- `frontend/scripts/check-env.mjs` — pre-flight validator
+- `skills/security.md` — broader security policy
+- `docs/runbooks/deployment-runbook.md` — references this doc for env setup
+- `CLAUDE.md` Section 6 — the one-line "no .env files committed" rule

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,163 @@
+# Frontend Logging
+
+> **Where this lives:** This document captures the logging patterns for the frontend template. When ticket #32 (Sentry / `skills/observability.md`) lands, the contents here should fold into `skills/observability.md` as the "Logging" section. Until then, this is the canonical reference.
+
+## Why a logger and not `console.log`
+
+Scattered `console.log` calls have three problems:
+
+1. **They're not searchable in production.** Console output disappears the moment the user closes the tab. Production debugging requires a log aggregator, which means structured entries with consistent fields.
+2. **They leak.** A `console.log({ user, token })` in dev ships to prod and exposes secrets in the user's devtools or in screen-recordings shared in support tickets.
+3. **They have no level discipline.** Everything is the same colour. There's no way to filter "show me only errors" without `Ctrl+F`-ing through the noise.
+
+The logger fixes all three. Use it instead of `console.*`. ESLint will block direct `console.*` calls everywhere except inside `src/lib/logger.ts` itself.
+
+## The API
+
+```ts
+import { logger } from './lib/logger';
+
+logger.debug('verbose detail', { traceId });             // stripped in prod
+logger.info('user submitted form', { feature, action });  // notable but expected
+logger.warn('retrying after 5xx', { statusCode: 503 });   // unexpected, recoverable
+logger.error('checkout failed', err, { feature, userId }); // needs investigation
+```
+
+Every method takes an optional **structured context** object typed as `LogContext`. The transport is responsible for serializing it (the dev console transport pretty-prints, the production Sentry transport will JSON-stringify into a breadcrumb).
+
+## Levels — when to use each
+
+| Level | Use it for | Don't use it for |
+|---|---|---|
+| `debug` | Verbose flow tracing while developing a feature | Anything you want to see in production — `debug` is stripped at runtime when `import.meta.env.MODE === 'production'` |
+| `info` | User actions, completed flows, navigation events, external API calls | High-frequency events (mouse moves, scroll, every keystroke) — those drown out signal |
+| `warn` | Retries, fallbacks, degraded behavior, unexpected-but-handled conditions | Things that are actually fine — don't cry wolf |
+| `error` | Caught exceptions, failed assertions, anything you'd want a Sentry alert for | Validation errors that are user input mistakes (those are `info` at most) |
+
+## When to log
+
+**Yes:**
+
+- A user clicks a destructive action (delete, refund, send) — log `info` with the action name and an opaque user ID
+- An API call returns 4xx or 5xx — log `warn` (4xx) or `error` (5xx) with the endpoint and status
+- A code path catches an exception — log `error` with the original Error object so the stack trace makes it to Sentry
+- A feature flag is checked and the result alters a flow — log `debug` with the flag name (helps trace which branch ran)
+- A long-running operation finishes — log `info` with `durationMs`
+
+**No:**
+
+- Inside a tight loop or render path — logs in render functions will fire on every re-render and overwhelm the transport
+- For routine reads (`GET /api/items` returning 200) — there's no signal here
+- For data the user can already see on the page (the contents of a chart they're looking at)
+- For *every* state change — pick the load-bearing transitions, not all of them
+
+## What NOT to put in `LogContext`
+
+The logger does **not** redact for you. You are responsible for not passing dangerous data into the context object.
+
+**Never log:**
+
+- Email addresses, full names, phone numbers, physical addresses
+- Auth tokens, API keys, session IDs, refresh tokens
+- Passwords (obvious but worth saying)
+- Full request bodies for write endpoints (may contain credentials)
+- Free-text user input that could contain PII
+
+**Use opaque IDs instead:**
+
+```ts
+// BAD
+logger.info('user logged in', { email: user.email, name: user.fullName });
+
+// GOOD
+logger.info('user logged in', { userId: user.id });
+```
+
+If you need to debug a specific user's session, look up their record by ID in the admin tool. Logs are for patterns, not individuals.
+
+## Adding context
+
+The `LogContext` type has a few well-known fields (`userId`, `feature`, `action`, `traceId`, `statusCode`, `durationMs`) and accepts arbitrary additional fields via the `[key: string]: unknown` index signature. **Prefer the well-known fields** when they fit — they make logs searchable across features.
+
+For new fields that are likely to recur, add them to the `LogContext` interface in `src/lib/logger.ts` so the type guides the next caller.
+
+## Good vs bad logs
+
+```ts
+// BAD: unstructured, leaks PII, no context
+console.log('User ' + user.email + ' clicked submit on ' + Date.now());
+
+// GOOD: structured, opaque ID, well-known fields
+logger.info('form submitted', {
+  userId: user.id,
+  feature: 'shipping-bill-search',
+  action: 'submit-search-form',
+});
+```
+
+```ts
+// BAD: error object discarded, no stack trace makes it to Sentry
+catch (e) {
+  console.log('something failed: ' + e);
+}
+
+// GOOD: full Error preserved, context attached
+catch (err) {
+  logger.error('shipping bill fetch failed', err as Error, {
+    feature: 'shipping-bill-list',
+    statusCode: 500,
+  });
+}
+```
+
+```ts
+// BAD: high-frequency, will overwhelm the transport
+useEffect(() => {
+  logger.debug('component re-rendered', { props });
+});
+
+// GOOD: log the load-bearing transition only
+useEffect(() => {
+  logger.debug('shipping bill list loaded', { count: bills.length });
+}, [bills.length]);
+```
+
+## How logs flow
+
+**Development** (`import.meta.env.MODE !== 'production'`):
+
+```
+logger.info(...) → consoleTransport → console.info(prefix, msg, ctx)
+```
+
+You see colour-coded entries in the browser devtools console with the timestamp, level, and inlined context object.
+
+**Production** (`import.meta.env.MODE === 'production'`):
+
+```
+logger.info(...) → noopTransport → /dev/null   (until ticket #32 lands)
+logger.error(...) → noopTransport → /dev/null
+```
+
+This is intentional. Until Sentry is wired up (ticket #32), logging in production is a no-op so the bundle stays clean and there's no risk of accidentally leaking. Once Sentry is initialised in `main.tsx`, the host app should call `setLogTransport` with a Sentry-backed transport. The example is documented in the JSDoc for `setLogTransport` in `src/lib/logger.ts`.
+
+After ticket #32:
+
+```
+logger.info(...)  → sentryTransport → Sentry.addBreadcrumb({ level: 'info', ... })
+logger.warn(...)  → sentryTransport → Sentry.addBreadcrumb({ level: 'warning', ... })
+logger.error(...) → sentryTransport → Sentry.captureException(err, { extra: ctx })
+logger.debug(...) → no-op in production (stripped before reaching the transport)
+```
+
+## ESLint enforcement
+
+The frontend ESLint config bans `console.*` everywhere except `src/lib/logger.ts` and `src/lib/logger.test.ts`. If you try to commit a `console.log`, the pre-commit hook will fail. The fix is to use `logger` instead, not to suppress the rule.
+
+## Cross-references
+
+- Implementation: [`../frontend/src/lib/logger.ts`](../frontend/src/lib/logger.ts)
+- Tests: [`../frontend/src/lib/logger.test.ts`](../frontend/src/lib/logger.test.ts)
+- ESLint config: [`../frontend/eslint.config.js`](../frontend/eslint.config.js)
+- Future Sentry integration: ticket #32 (5.1)
+- Future `skills/observability.md`: also from ticket #32 — when it lands, fold this document into it

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,58 @@
+# Runbooks
+
+This directory contains **operational runbooks** — step-by-step procedures the team follows during real, time-sensitive operations: deploys, incidents, rollbacks, recovery from outages.
+
+## Runbooks vs skill files vs ADRs
+
+The team has three different documentation surfaces, and they answer different questions. Knowing which one to read (or write) saves a lot of confusion:
+
+| Surface | Question it answers | When you read it | Tone |
+|---|---|---|---|
+| **`skills/`** | *How do I write code that follows our patterns?* | While coding, before a PR | Conceptual, with examples |
+| **`docs/adrs/`** | *Why does the project look the way it does?* | Onboarding, before refactoring | Historical, explains tradeoffs |
+| **`docs/runbooks/`** (you are here) | *What do I do, right now, in this exact situation?* | During a deploy, an incident, an outage | Imperative, copy-pasteable |
+
+A skill file might say *"use multi-stage Docker builds"*. The deployment runbook tells you *"step 3: run `docker build --target=production -t app:$(git rev-parse --short HEAD) .`"*. Different question, different answer.
+
+## When to write a runbook
+
+Write a runbook when:
+
+- The procedure is **operational** (you run it, not write it)
+- The procedure is **time-sensitive** (someone needs it at 2am, half-asleep)
+- The procedure has **decision points** ("if X, do Y; if Z, escalate")
+- The procedure has **rollback or recovery** steps
+- The cost of a mistake is high (production deploys, schema migrations, incident response)
+
+If a procedure is run rarely and casually (quarterly dependency upgrade review, etc.), a doc in `docs/` is enough. Reserve runbooks for the things you'd want a printed copy of when the network is down.
+
+## Runbook standards
+
+Every runbook in this directory follows the same shape so a half-asleep engineer can find what they need:
+
+1. **Owner** — which team or rotation maintains it
+2. **When to use this runbook** — concrete trigger conditions
+3. **Pre-conditions / pre-flight checklist** — what must be true before you start
+4. **Steps** — numbered, copy-pasteable, with timing estimates
+5. **Verification** — how you know each step worked
+6. **Rollback** — how to undo, with a clear point-of-no-return marker if there is one
+7. **Known issues** — common failures and their fixes
+8. **Escalation** — who to page if you're stuck
+
+Write runbooks in the second person (*"You will run..."*), present tense, and assume the reader is in a hurry. Cut every word that isn't load-bearing.
+
+## Current runbooks
+
+| File | Purpose | Owner |
+|---|---|---|
+| [`deployment-runbook.md`](./deployment-runbook.md) | Production deploys (any project cloned from this template) | On-call engineer |
+| [`incident-response.md`](./incident-response.md) | First-10-minutes response to a production incident, severity definitions, comms protocol, resolution flow | On-call engineer |
+| [`postmortem-template.md`](./postmortem-template.md) | Blameless postmortem template for use within 48 hours of any SEV1 or SEV2 incident | Incident commander |
+
+## Cross-references
+
+- **Skill files:** [`../../skills/`](../../skills/) — patterns and conventions
+- **ADRs:** [`../adrs/`](../adrs/) — historical decisions
+- **CLAUDE.md:** [`../../CLAUDE.md`](../../CLAUDE.md) — master instructions for Claude Code
+- **Google SRE Book — Writing Runbooks:** https://sre.google/sre-book/being-on-call/
+- **PagerDuty incident response guide:** https://response.pagerduty.com/

--- a/docs/runbooks/deployment-runbook.md
+++ b/docs/runbooks/deployment-runbook.md
@@ -1,0 +1,257 @@
+# Deployment Runbook
+
+> **Owner:** On-call engineer (rotation tracked in team calendar)
+> **Pairs with:** [`skills/deployment.md`](../../skills/deployment.md) — the *patterns*. This runbook is the *procedure*.
+> **Estimated duration:** 25–45 minutes for a normal deploy. Add 15 minutes if rollback is needed.
+
+This runbook is the canonical procedure for deploying any project cloned from `agentspace-dev-template` to production. **Read it once before your first deploy.** Then use it as a checklist every time.
+
+If something in this runbook is wrong or missing, fix it after the deploy and open a PR. Runbooks are written in advance, but they only get accurate when people use them and find the gaps.
+
+## When to use this runbook
+
+Use this runbook when:
+
+- A PR has been merged to `main` and needs to ship to production
+- A hotfix needs to ship out of band
+- A scheduled release is being cut
+
+**Do NOT use this runbook for:**
+
+- Local development (`npm run dev`)
+- Staging deploys (those are auto-triggered by merges to `develop`, no human action required)
+- Database migrations without a paired code deploy (those have their own runbook — TBD, see ticket on incident runbook)
+
+## Pre-flight checklist
+
+**Run through every item.** If any item is `[ ]` and you can't tick it, **stop and ask the team** before continuing. The cost of pausing for 5 minutes is much smaller than the cost of a bad deploy.
+
+- [ ] **CI is green on `main`** — `https://github.com/<org>/<repo>/actions?query=branch:main`
+- [ ] **The PR being deployed is merged**, not just approved
+- [ ] **You have read the PR description** and understand what's changing
+- [ ] **Tests passed locally** on `main` after pulling latest: `npm test && npm run build`
+- [ ] **Database migrations are reviewed and idempotent** (if applicable) — see migration runbook
+- [ ] **Feature flags for any half-built features are set to OFF in production env**
+- [ ] **Secrets and env vars are present** in the production environment (verify via `[hosting provider] dashboard`)
+- [ ] **No active incident is in progress** (check the incident channel)
+- [ ] **It is not Friday after 14:00 IST** unless this is a hotfix — Friday-evening deploys are banned by team policy
+- [ ] **Comms sent**: post a message in the `#deploys` channel with: ticket link, PR link, your name, expected duration
+- [ ] **Rollback plan is clear in your head** — see the Rollback section below before you start
+
+## Deploy steps
+
+### Step 1 — Pin the deploy target (1 min)
+
+Tag the commit you're shipping. This is your rollback anchor.
+
+```bash
+git checkout main
+git pull origin main
+git rev-parse HEAD
+# Copy the SHA — you will need it for verification and rollback
+```
+
+Note the short SHA (first 7 characters) somewhere visible. From here on it's the *deploy SHA*.
+
+### Step 2 — Verify the build artifact (3 min)
+
+Run a clean build locally to confirm the SHA compiles cleanly. Production builds occasionally fail when local builds (which use cached state) don't.
+
+```bash
+cd frontend
+rm -rf node_modules dist
+npm ci
+npm run build
+```
+
+**Verify:**
+- Build exits with code 0
+- `dist/` directory exists
+- `dist/index.html` references hashed JS/CSS bundles
+- No warnings about missing env vars
+
+If anything is off, **STOP**. Open a follow-up ticket and let the team know in `#deploys`.
+
+### Step 3 — Trigger the production deploy (5 min)
+
+[FILL_PER_PROJECT — replace with the actual deploy command for your project]
+
+```bash
+# Example for Vercel:
+# vercel --prod --confirm
+#
+# Example for AWS S3 + CloudFront:
+# aws s3 sync dist/ s3://[BUCKET_NAME]/ --delete
+# aws cloudfront create-invalidation --distribution-id [DIST_ID] --paths "/*"
+#
+# Example for GitHub Actions production workflow:
+# gh workflow run production-deploy.yml --ref main
+```
+
+**Verify the deploy started:**
+- Check the deploy provider's dashboard for an in-progress build
+- Note the build ID — paste it into `#deploys`
+
+### Step 4 — Wait for deploy completion (5–15 min)
+
+Watch the build logs in real time. Don't multitask. If the build fails partway through, you need to know immediately.
+
+**If the build succeeds:** Move on to Step 5.
+
+**If the build fails mid-way:**
+- Capture the error
+- Post to `#deploys` immediately
+- Go to **Rollback — Build failure** below
+
+## Verification (the most important part)
+
+The deploy is **not done** until verification passes. Resist the urge to declare victory the moment the build is green.
+
+### Step 5 — Smoke test the deployed app (5 min)
+
+Open the production URL in an incognito window (no cached state).
+
+- [ ] **Page loads** without console errors
+- [ ] **The deploy SHA is visible** in the page footer or via the version endpoint (if your project exposes one)
+- [ ] **Auth works** — log in with a test account
+- [ ] **At least one read endpoint returns data** — open the main dashboard, confirm KPIs render
+- [ ] **At least one write endpoint succeeds** — perform a non-destructive write (e.g., apply a filter, save a preference)
+- [ ] **No 4xx/5xx in the network tab** during the smoke test
+
+### Step 6 — Watch error rates and key metrics (10 min)
+
+Open the observability dashboard and watch for 10 minutes after Step 5 finishes.
+
+**Watch:**
+- **Error rate** — should remain at or below the pre-deploy baseline. A spike of more than 2× baseline is a rollback trigger.
+- **p95 latency on the main API endpoints** — should not jump by more than 50%.
+- **Sentry / error tracker** — no new error types appearing
+- **5xx count** — no sustained 5xx responses
+
+**If any of these go red, go to Rollback — Post-deploy regression.**
+
+### Step 7 — Mark the deploy complete (1 min)
+
+Once Step 6 is clean for 10 full minutes:
+
+- Post in `#deploys`: *"Deploy of `<deploy-SHA>` complete and verified. No regressions in 10-minute window."*
+- Update the deploy log (if your team keeps one)
+- You're done.
+
+## Decision tree: succeeded vs failed
+
+```
+Did Step 4 (build) succeed?
+├── No  → Rollback — Build failure
+└── Yes → Did Step 5 (smoke test) pass?
+          ├── No  → Rollback — Smoke test failure
+          └── Yes → Did Step 6 (10-minute watch) stay clean?
+                    ├── No  → Rollback — Post-deploy regression
+                    └── Yes → Done. Mark complete in #deploys.
+```
+
+## Rollback procedure
+
+The rollback path you take depends on **where** the deploy failed.
+
+### Rollback — Build failure (deploy never went live)
+
+**Easy case.** The previous version is still serving traffic. No user impact.
+
+1. Cancel the failed build in the deploy provider dashboard
+2. Post to `#deploys`: *"Deploy of `<deploy-SHA>` failed at build step. Production unchanged. Investigating."*
+3. Capture the build log
+4. Open a ticket with the failure details
+5. Do NOT retry until the root cause is understood
+
+### Rollback — Smoke test failure (deploy went live, app is broken)
+
+**Time-sensitive.** Users are seeing the broken version. Move fast.
+
+1. Identify the **previous good deploy SHA** — find it in the deploy provider's history
+2. Re-deploy that SHA immediately:
+
+```bash
+# [FILL_PER_PROJECT — exact rollback command for your hosting provider]
+# Example for Vercel: navigate to deploys page → click "Promote to Production" on previous build
+# Example for S3+CloudFront: re-upload from the previous git tag and invalidate
+```
+
+3. **Verify rollback** — re-run Step 5 against the rolled-back app. Confirm the broken behaviour is gone.
+4. Post to `#deploys`: *"Rolled back from `<bad-SHA>` to `<good-SHA>`. Production is healthy. Investigating root cause."*
+5. **Open a P0 incident ticket** with the failure details
+6. Do not attempt a re-deploy until the root cause is documented in the incident
+
+### Rollback — Post-deploy regression (deploy went live, error rates spiked)
+
+Same procedure as the smoke test failure rollback. The only difference is **how** you found the regression (metrics vs manual test).
+
+**Important:** If the regression is caused by a database migration that ran during the deploy, **you cannot just roll back the code**. The migration is forward-only by default. Stop, page Chinmay, and follow the migration recovery runbook (TBD).
+
+### Point of no return
+
+Some deploys cross a point-of-no-return where rollback is no longer safe — typically when an irreversible database migration has run and new writes are using the new schema. **If you suspect you're past PNR, do not roll back.** Stop, page Chinmay, and proceed under their direction.
+
+## Known issues
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Build fails with `Error: Cannot find module` | Lock file out of sync | `rm -rf node_modules package-lock.json && npm install` locally, commit, redeploy |
+| Smoke test 401s on every endpoint | Auth env var not set in prod | Check secret manager, set the missing var, restart the deploy |
+| App loads but charts are empty | API base URL points at staging | Check `VITE_API_BASE_URL` in production env vars |
+| 5xx spike right after deploy | Database connection pool exhausted | Check DB max connections — may need to scale before retrying |
+| `Mixed Content` errors in console | App served over HTTPS but calling `http://` API | Update API base URL to `https://` |
+| White screen, no errors | Service worker cached old `index.html` | Hard refresh; if persistent, deploy a cache-busting fix |
+
+Add to this table whenever you hit something new during a deploy.
+
+## Escalation
+
+Page in this order. Do not skip levels unless the higher level is unreachable.
+
+1. **First responder:** the on-call engineer (you, probably). Try to fix the issue using this runbook.
+2. **Tech lead:** Chinmay — for backend, infra, or database issues.
+3. **Frontend lead:** Tanay — for UI regressions, build chain issues, or design-system problems.
+4. **PM:** for any user-facing communication or status page updates.
+
+**Escalation channels:**
+
+- `#deploys` (Slack) — first stop for real-time coordination
+- Direct DM if `#deploys` is quiet and the issue is critical
+- Phone call if DMs aren't being read and impact is ongoing
+
+Never resolve an outage silently. Even if you fix it in 30 seconds, post the fix in `#deploys` so the team has a record.
+
+## Post-deploy checklist
+
+Once the deploy is complete and verified:
+
+- [ ] `#deploys` notified of success
+- [ ] Deploy SHA recorded somewhere durable
+- [ ] If anything in this runbook was wrong or missing, open a PR to fix it
+- [ ] If this was a hotfix, update the incident ticket with the fix SHA
+- [ ] Take a sip of water, you earned it
+
+## Project-specific configuration
+
+[FILL_PER_PROJECT — fill these in once and they apply to every deploy of this project]
+
+| Field | Value |
+|---|---|
+| Production URL | [e.g., https://app.example.com] |
+| Hosting provider | [e.g., Vercel, AWS, Azure] |
+| Build artifact location | [e.g., `frontend/dist/`] |
+| Deploy command | [exact command] |
+| Rollback command | [exact command] |
+| Observability dashboard | [URL] |
+| Error tracker | [Sentry project URL] |
+| On-call rotation | [link to schedule] |
+| Status page | [URL, if any] |
+
+## Cross-references
+
+- **Skill file:** [`../../skills/deployment.md`](../../skills/deployment.md) — patterns, Dockerfile templates, CI structure
+- **Runbooks index:** [`./README.md`](./README.md)
+- **Incident response runbook:** TBD (ticket #44)
+- **Dependency upgrades:** [`../dependency-upgrades.md`](../dependency-upgrades.md)
+- **Google SRE Book — Release Engineering:** https://sre.google/sre-book/release-engineering/

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,246 @@
+# Incident Response Runbook
+
+> **Owner:** On-call engineer
+> **Pairs with:** [`postmortem-template.md`](./postmortem-template.md) (use within 48h of any SEV1 or SEV2)
+> **First read:** Now, while nothing is broken. Not at 2am.
+
+This runbook is the canonical first-10-minutes procedure for any production incident on an Agent Space project. It exists so that when something is on fire, you don't have to invent a process — you just follow the steps.
+
+**Print or bookmark this. Don't try to find it during an incident.**
+
+## When to use this runbook
+
+You should be following this runbook the moment any of these is true:
+
+- A user-visible feature is broken in production
+- The error rate has spiked above the alerting threshold
+- A deploy has caused a regression that wasn't caught by the [deployment runbook](./deployment-runbook.md)
+- The status page is showing a green status but reality is showing red
+- Customer support is reporting a flood of complaints about the same thing
+
+If you're not sure whether something is an incident, **assume it is** and follow the runbook. The cost of treating a non-incident as an incident is 10 minutes of process. The cost of the reverse is much higher.
+
+## Severity levels
+
+The first decision in any incident is the severity. It determines who you wake up and how fast.
+
+| Level | Definition | Response time | Examples |
+|---|---|---|---|
+| **SEV1** | Total outage, data loss, or security breach. The product is unusable for most users. | **5 minutes.** Page everyone. | Site is down, database is corrupted, auth is fully broken, secret is leaked |
+| **SEV2** | Significant feature is broken. A meaningful subset of users cannot accomplish a meaningful workflow. | **30 minutes.** Page on-call + tech lead. | Search returns no results, exports time out, login is intermittent, key page won't load |
+| **SEV3** | Degraded experience. Users can work around it. | **1 business day.** Async ticket. | A chart renders wrong, a non-critical button doesn't work, a metric is slow |
+
+If you're between two levels, **pick the higher one**. You can downgrade. Upgrading mid-incident wastes the most valuable resource (the first 10 minutes).
+
+## First 10 minutes — the checklist
+
+**Walk through every step.** Don't skip ahead.
+
+### 0:00 — 0:30 — Acknowledge
+
+- [ ] Acknowledge the alert (in PagerDuty / Sentry / wherever it came from). This stops the page from re-firing and tells the rest of the team someone is on it.
+- [ ] Open the team channel (`#incidents` if it exists, otherwise the main team channel)
+- [ ] Post a quick hold message:
+
+```
+🚨 Investigating possible incident — alert: <link or summary>. More in 5 min. — <your name>
+```
+
+The point of this message is **not** to communicate the problem. It's to tell the team that you've seen the alert and are looking. Without it, three other people will wake up and start investigating in parallel.
+
+### 0:30 — 2:00 — Assess severity
+
+- [ ] What's broken? Be specific. "Login" is too vague. "Login form returns 500 on submit for users on the password flow" is useful.
+- [ ] Who is affected? "All users" or "users on plan X" or "one customer in Brazil"?
+- [ ] How bad is it? Pick a SEV level using the table above.
+- [ ] Are users actively losing data or money? If yes, this is SEV1 regardless of other factors.
+
+### 2:00 — 5:00 — Open the incident
+
+- [ ] Create a thread or new channel for the incident. Pin or link it from the team channel.
+- [ ] Start the incident timeline doc. This is the running record of what happened, when, and who did what. The simplest format works:
+
+```
+## Incident: <one-line description>
+- Severity: SEVx
+- Started: 2026-04-11 14:23 IST (when the alert fired)
+- Detected: 2026-04-11 14:25 IST (when a human noticed)
+- Incident commander: <your name>
+
+### Timeline
+14:25 — Alert fired (Sentry: Foo.tsx:42 ReferenceError)
+14:26 — IC acknowledged
+14:28 — Severity assessed as SEV2
+14:31 — ...
+```
+
+- [ ] Assign roles (for SEV1 or SEV2):
+  - **Incident Commander (IC)** — runs the incident, makes decisions, NOT the same person debugging
+  - **Investigator** — actually digs into the code/logs/dashboards
+  - **Communicator** — posts updates to the team channel and status page
+  - For SEV3, one person can be all three.
+
+### 5:00 — 8:00 — Initial investigation
+
+- [ ] Check Sentry / error tracker for recent error groups. Has anything spiked in the last 30 minutes?
+- [ ] Check the [deploy log](./deployment-runbook.md). Was there a deploy in the last hour? **A recent deploy is the most likely cause of any sudden incident.**
+- [ ] Check the dependency status: backend API health endpoint, database, CDN, DNS, Sentry itself.
+- [ ] Check the Lighthouse / performance dashboard if it's a slowness issue.
+- [ ] Reproduce the issue in an incognito browser if possible. Confirm it's not just one user's cache.
+
+**If a recent deploy is the cause, your first instinct should be to roll back.** Investigate later. Rollback procedure is in the [deployment runbook](./deployment-runbook.md). The rule is: **mitigate first, fix later.**
+
+### 8:00 — 10:00 — Communicate
+
+- [ ] Post the first real status update to the team channel. Use this template:
+
+```
+🔴 SEVx incident open
+What's broken: <one sentence, user-visible>
+Impact: <who is affected, how>
+Started: <time>
+What we know: <2-3 bullets>
+What we're doing: <2-3 bullets>
+Next update: in 15 minutes (or when the situation changes)
+IC: <name>
+```
+
+- [ ] If SEV1 or any customer-facing impact: update the status page (if the project has one)
+- [ ] If SEV1: alert the PM so they can prepare customer comms
+
+## Investigation steps (after the first 10 minutes)
+
+Now you have a few minutes to think. Work the problem.
+
+### Common investigation paths
+
+**"Errors started 30 minutes ago"**
+1. What deployed in the 30 minutes before the errors started?
+2. Roll back the deploy. Verify errors stop.
+3. Open a ticket for the actual fix.
+
+**"Page is slow"**
+1. Check the Lighthouse dashboard
+2. Check the backend API latency
+3. Check CDN status
+4. Check the user's region — could be a regional CDN issue
+
+**"Login is broken"**
+1. Check the auth provider's status page
+2. Check if the JWT signing key has rotated
+3. Check `VITE_API_BASE_URL` is correct in the production env
+4. Check CORS errors in the browser console
+
+**"Data is wrong / missing"**
+1. **STOP. Do not roll back yet** — a rollback may make data loss worse.
+2. Check whether the bad data is being written or just displayed wrong.
+3. If being written: page Chinmay immediately. Stop new writes if possible (feature flag the affected flow off).
+4. If just displayed wrong: rollback is safe.
+
+**"Sentry is showing errors but users aren't complaining"**
+1. Check the error volume vs baseline. A 2× spike from a low base may not be customer-impacting.
+2. Check whether the error is in a code path that has a fallback.
+3. Don't assume "no complaints = no impact." Some users just leave.
+
+## Communication protocol
+
+### Cadence
+
+- **SEV1:** team channel update **every 15 minutes** until resolved
+- **SEV2:** team channel update **every 30 minutes** until resolved
+- **SEV3:** post when the issue is identified and again when resolved — no scheduled cadence
+
+Even if there's nothing new to say, post: *"Still investigating. No new info. Next update in 15 min."* Silence makes everyone assume the worst.
+
+### Who to notify by severity
+
+| Level | Initial page | Updates | Resolution |
+|---|---|---|---|
+| SEV1 | On-call + Tech lead (Chinmay) + PM + Frontend lead (Tanay) | Team channel + DM to PM | Team channel + PM + customer success |
+| SEV2 | On-call + Tech lead (Chinmay) | Team channel | Team channel |
+| SEV3 | On-call | Team channel | Team channel |
+
+### Customer comms templates
+
+**Status page — initial (SEV1 or SEV2 with customer impact):**
+
+```
+We are investigating reports of <one sentence — user-visible problem>.
+Some users may experience <impact>. We are working on a fix and will
+post another update within 30 minutes.
+```
+
+**Status page — update:**
+
+```
+Update: We have identified the cause of <issue>. <What's being done.>
+We expect resolution within <time>. Next update: <time>.
+```
+
+**Status page — resolved:**
+
+```
+Resolved: <Issue> has been resolved as of <time>. Affected users may
+need to refresh their browser. We will publish a postmortem within 48
+hours.
+```
+
+Keep customer-facing language **factual, non-defensive, and short**. Don't apologise excessively. Don't blame anyone. Don't promise things you can't deliver.
+
+## Resolution
+
+When you believe the incident is resolved:
+
+1. **Verify the fix works.** Re-run the manual test that caught the original problem. Watch metrics for 10 minutes after the fix lands. **Do not declare resolved until metrics have actually returned to baseline.**
+2. **Update the status page** with the resolved message.
+3. **Post the resolution to the team channel** with a one-paragraph summary:
+   ```
+   ✅ SEVx incident resolved at <time>.
+   What was broken: <one sentence>
+   Root cause: <one sentence — preliminary, full RCA in postmortem>
+   How fixed: <one sentence>
+   Total duration: <minutes>
+   Postmortem: scheduled for <time>
+   ```
+4. **Schedule the postmortem within 48 hours.** SEV1 and SEV2 always require a postmortem. SEV3 is optional based on the IC's judgment.
+5. **Close the incident channel** (or unpin the thread).
+
+## Post-incident
+
+Within 48 hours of any SEV1 or SEV2:
+
+- [ ] Schedule a 30-60 minute postmortem meeting. All on-call participants attend. PM and tech lead attend.
+- [ ] Use the [postmortem template](./postmortem-template.md) to structure the discussion and the writeup.
+- [ ] **Blameless.** The postmortem is about the system, not the people. If a postmortem is becoming about who screwed up, redirect it.
+- [ ] Action items get tickets, owners, and due dates. Action items without owners are wishes, not commitments.
+- [ ] Publish the postmortem to the team. Internal-facing for SEV2, customer-facing summary for SEV1 if there was external impact.
+
+## Roles cheat sheet
+
+When you're paged into a SEV1 or SEV2 with multiple people responding:
+
+| Role | Responsibility | What they do NOT do |
+|---|---|---|
+| **Incident Commander (IC)** | Runs the incident. Makes decisions. Coordinates. Decides when to escalate, when to roll back, when it's resolved. | Debug code. Read logs. Reproduce bugs. The IC's job is to coordinate, not to fix. |
+| **Investigator** | Reads logs, reproduces the bug, finds the root cause, writes the fix. | Communicate updates. Decide severity. The investigator should be heads-down, not context-switching. |
+| **Communicator** | Posts updates to team channel and status page on the cadence above. Drafts customer comms. | Investigate. Communicate is a full-time role during a SEV1. |
+
+For a SEV3 with one person, all three roles collapse into "you." For a SEV2, IC + Investigator is the minimum split. For a SEV1, all three should be different people.
+
+## What NOT to do during an incident
+
+- **Don't blame.** Even if you're sure who broke it. Blame slows down the response and poisons the postmortem. Time for accountability is *after*, in the postmortem, with system fixes.
+- **Don't solo-debug a SEV1.** Two people are 4× as fast, not 2×, because one of them notices the thing the other missed.
+- **Don't deploy fixes without verification.** The temptation to ship a "quick fix" is always strong. The quick fix often makes it worse. Verify the fix locally first.
+- **Don't skip the postmortem.** "We already know what happened" is exactly when you most need a structured postmortem to find the systemic issues.
+- **Don't communicate by DM.** Everything goes in the incident channel so the timeline is preserved. DMs are invisible and forgotten.
+- **Don't keep working past your effectiveness.** If you've been on for 4 hours straight, hand off. Tired investigators make mistakes.
+
+## Cross-references
+
+- [`deployment-runbook.md`](./deployment-runbook.md) — covers the rollback procedure that this runbook references
+- [`postmortem-template.md`](./postmortem-template.md) — the blameless postmortem template
+- `skills/security.md` — if the incident is a security breach, also follow the security incident escalation
+- `docs/logging.md` — how to read structured logs from the logger
+- Google SRE Book — Incident Management: https://sre.google/sre-book/managing-incidents/
+- PagerDuty Incident Response: https://response.pagerduty.com/

--- a/docs/runbooks/postmortem-template.md
+++ b/docs/runbooks/postmortem-template.md
@@ -1,0 +1,141 @@
+# Postmortem: [One-line description of the incident]
+
+> **This is a template.** Copy it to `docs/postmortems/YYYY-MM-DD-short-name.md` (create the directory if needed) and fill in every section. Delete this header.
+>
+> **Postmortems are blameless.** Focus on the systems and processes that allowed the incident, not on the individuals involved. If you find yourself writing "X should have known better," rephrase as "the system did not give X enough information to make a different decision." That is the actual problem to fix.
+
+## Metadata
+
+- **Severity:** SEV1 / SEV2 / SEV3
+- **Date:** YYYY-MM-DD
+- **Duration:** HH:MM (from first impact to resolution)
+- **Incident commander:** [name]
+- **Investigators:** [names]
+- **Authors of this document:** [names]
+- **Status:** draft / in review / final
+
+## Summary
+
+Two or three sentences. What broke, who was affected, how long it lasted, how it was fixed. Imagine someone reading only the summary — they should still understand the incident.
+
+Example: *"On 2026-04-08, between 14:23 and 15:11 IST, the shipping bill search returned 500 errors for all users. The cause was a missing index on the `shipping_bills.created_at` column after a migration. Resolved by adding the index. Approximately 230 users impacted, no data loss."*
+
+## Impact
+
+Be specific. Numbers, not adjectives.
+
+- **Users affected:** [count or "all users", or "users on plan X"]
+- **Duration of impact:** [HH:MM]
+- **Geographic scope:** [global / region / specific tenant]
+- **Data loss:** [yes / no — and if yes, how much and what]
+- **Revenue impact:** [if known and meaningful]
+- **Customer-visible:** [yes / no — were complaints filed?]
+
+## Timeline
+
+Use the live timeline kept in the incident channel. Cleaned up but **not** edited to make anyone look better. Honest timestamps.
+
+| Time (IST) | Event |
+|---|---|
+| 14:23 | Alert fired (Sentry: `BillSearch.tsx:42 ReferenceError`) |
+| 14:25 | On-call (Akshat) acknowledged |
+| 14:27 | Severity assessed as SEV2 |
+| 14:30 | Incident channel opened, IC assigned |
+| 14:35 | Identified that the issue started 5 min after the 14:18 deploy |
+| 14:38 | Decision: roll back the deploy |
+| 14:42 | Rollback complete; verified errors stopped |
+| 14:45 | Status page updated to "investigating" |
+| 14:51 | Status page updated to "monitoring" |
+| 15:11 | Incident declared resolved after 20-minute clean window |
+
+## Root cause analysis
+
+What actually caused the incident? Walk through the chain.
+
+**5 Whys** is a useful structure, but don't stop at the first technical answer. Push to the underlying systemic cause.
+
+Example:
+
+1. **Why did search return 500?** Because the database query timed out.
+2. **Why did the query time out?** Because there was no index on `shipping_bills.created_at`.
+3. **Why was there no index?** Because the migration that added the column didn't add the index.
+4. **Why didn't the migration add the index?** Because the developer wasn't aware that this column would be used as a query filter.
+5. **Why wasn't this caught in review?** Because the migration PR and the search PR were reviewed independently, and no reviewer was looking at the connection between them.
+
+The root cause here is **not** "the developer forgot the index." The root cause is **"the review process doesn't catch missing indexes when query filters and migrations are split across PRs."** That's the thing to fix.
+
+## Contributing factors
+
+Things that didn't directly cause the incident but made it worse or harder to detect.
+
+- The error rate alert threshold was set too high; the spike took 4 minutes to fire
+- The monitoring dashboard didn't show DB query latency on the main view
+- The on-call playbook didn't include "check recent migrations" as a common cause
+- ...
+
+## What went well
+
+This section is non-negotiable. Every postmortem includes it. The point is to identify the things you want to keep doing — celebrate them publicly so they become habit.
+
+- Alert fired within 4 minutes of impact
+- IC was assigned within 7 minutes of the alert
+- Rollback decision was made fast and was the right call
+- Communication on the status page was timely and clear
+- Total time to mitigation: 15 minutes (well within SLA)
+
+## What went wrong
+
+Process, tooling, and system failures only. Not individual mistakes.
+
+- The migration review didn't surface the missing index
+- The error rate alert took 4 minutes to fire (too high a threshold)
+- The communicator role wasn't assigned, so customer comms came late
+- We didn't have a runbook for "what to check when search times out"
+
+## Action items
+
+Concrete, owned, dated. No action items without all three.
+
+| # | Action | Owner | Due | Ticket |
+|---|---|---|---|---|
+| 1 | Add `created_at` index to `shipping_bills` table | Chinmay | 2026-04-12 | #88 |
+| 2 | Lower error rate alert threshold from 5% to 2% | Akshat | 2026-04-15 | #89 |
+| 3 | Add migration review checklist item: "any new column used as a query filter must have an index" | Chinmay | 2026-04-18 | #90 |
+| 4 | Add a "check recent migrations" step to the incident response runbook for DB-related incidents | Akshat | 2026-04-15 | #91 |
+| 5 | Add DB query latency to the main monitoring dashboard | Chinmay | 2026-04-30 | #92 |
+
+Vague action items are worthless. **"Improve testing"** is not an action item. **"Add a Cypress test for the search page filter happy path by 2026-04-20, owned by Tanay, ticket #93"** is.
+
+## Lessons learned
+
+Generalizable lessons that go beyond the specific incident.
+
+- "Review process needs to span related PRs, not just review them in isolation."
+- "Alert thresholds should be set based on user impact, not on internal noise tolerance."
+- "Every new column should be evaluated as 'will this be used in a WHERE clause' as part of migration review."
+
+These lessons should make their way into the relevant skill files, not just live in this postmortem. If a lesson is worth learning, it's worth codifying.
+
+## Sign-off
+
+- [ ] Postmortem reviewed by IC
+- [ ] Postmortem reviewed by tech lead
+- [ ] Action items have tickets
+- [ ] Action items have owners and due dates
+- [ ] Lessons learned have been added to the relevant skill files where applicable
+- [ ] Postmortem published to the team
+
+---
+
+## Appendix: blameless writing tips
+
+The phrase to internalize: **"Person X did Y" → "The system allowed Y to happen because Z"**.
+
+| Blameful (don't write) | Blameless (write this instead) |
+|---|---|
+| "Akshat forgot to add the index." | "The migration review process did not surface the missing index." |
+| "Tanay should have caught this in review." | "Two PRs that depend on each other were reviewed independently, with no mechanism to surface the dependency." |
+| "The on-call should have noticed sooner." | "The alert threshold was set too high; the alert fired 4 minutes after impact." |
+| "We need to be more careful." | "We need a checklist that catches this category of bug at review time." |
+
+The goal is not to make people feel good. The goal is to make the **system** better. A blameful postmortem teaches people to hide mistakes; a blameless one teaches the team to surface and fix them.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,19 @@
+# =============================================================================
+# .env.local.example — local development overrides
+# =============================================================================
+#
+# Copy this to .env.local and fill in. .env.local is gitignored and overrides
+# .env values.
+#
+# Use this for:
+#   - Pointing the frontend at a local backend you're running
+#   - Trying out a feature flag without touching the committed default
+#   - Testing against a staging API from your laptop
+#
+# Anything you put here is for YOUR machine only. Do not commit.
+# =============================================================================
+
+VITE_API_BASE_URL=http://localhost:3001/api
+
+# Uncomment to test feature flags locally
+# VITE_FLAG_EXAMPLE_NEW_DASHBOARD=true

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,0 +1,15 @@
+# =============================================================================
+# .env.production.example — production environment template
+# =============================================================================
+#
+# This file is a TEMPLATE. Real production values are set in the hosting
+# provider's secret manager — never committed.
+#
+# Copy this list when configuring production so you don't miss any required
+# variables.
+# =============================================================================
+
+VITE_API_BASE_URL=https://api.example.com/api
+VITE_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+VITE_SENTRY_ENVIRONMENT=production
+VITE_ANALYTICS_WRITE_KEY=<production-write-key>

--- a/frontend/.env.staging.example
+++ b/frontend/.env.staging.example
@@ -1,0 +1,15 @@
+# =============================================================================
+# .env.staging.example — staging environment template
+# =============================================================================
+#
+# This file is a TEMPLATE. Real staging values are set in the hosting
+# provider's secret manager (Vercel / Netlify / AWS / etc.) — never committed.
+#
+# Copy this list when configuring a new staging environment so you don't miss
+# any required variables.
+# =============================================================================
+
+VITE_API_BASE_URL=https://staging-api.example.com/api
+VITE_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+VITE_SENTRY_ENVIRONMENT=staging
+VITE_ANALYTICS_WRITE_KEY=<staging-write-key>

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,26 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: [
+    '../src/**/*.mdx',
+    '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-a11y',
+    '@storybook/addon-interactions',
+    '@storybook/addon-themes',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
+};
+
+export default config;

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,0 +1,42 @@
+import type { Preview } from '@storybook/react';
+
+// Pull in the project's Tailwind output so utility classes work in stories.
+// Storybook uses the same Vite + Tailwind v4 pipeline as the app.
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    backgrounds: {
+      default: 'app',
+      values: [
+        { name: 'app', value: '#f0f5fa' },
+        { name: 'white', value: '#ffffff' },
+        { name: 'dark', value: '#0f172a' },
+      ],
+    },
+    // Accessibility addon — runs axe on every story and reports violations.
+    // See skills/accessibility.md for the rules these checks enforce.
+    a11y: {
+      config: {
+        rules: [
+          // Color contrast can produce false positives in story isolation
+          // because the background may not match the production layout.
+          // Keep enabled — investigate any violations rather than disable.
+        ],
+      },
+      // Treat violations as test failures (CI-friendly).
+      manual: false,
+    },
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default preview;

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -1,0 +1,41 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:best-practices": ["warn", { "minScore": 0.95 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+
+        "largest-contentful-paint": ["error", { "maxNumericValue": 2500, "aggregationMethod": "median-run" }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "median-run" }],
+        "interaction-to-next-paint": ["error", { "maxNumericValue": 200, "aggregationMethod": "median-run" }],
+        "total-blocking-time": ["error", { "maxNumericValue": 300, "aggregationMethod": "median-run" }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 1800, "aggregationMethod": "median-run" }],
+        "speed-index": ["warn", { "maxNumericValue": 3400, "aggregationMethod": "median-run" }],
+
+        "resource-summary:script:size": ["error", { "maxNumericValue": 307200 }],
+        "resource-summary:stylesheet:size": ["warn", { "maxNumericValue": 51200 }],
+        "resource-summary:total:size": ["error", { "maxNumericValue": 512000 }],
+        "resource-summary:image:size": ["warn", { "maxNumericValue": 204800 }],
+
+        "uses-text-compression": "error",
+        "uses-responsive-images": "warn",
+        "modern-image-formats": "warn",
+        "uses-rel-preconnect": "warn",
+        "font-display": "warn",
+        "uses-passive-event-listeners": "error",
+        "no-document-write": "error",
+        "non-composited-animations": "warn"
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^9.39.4",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -356,6 +357,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -3943,17 +3954,48 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3962,13 +4004,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3989,9 +4031,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4002,13 +4044,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4016,14 +4058,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4032,9 +4074,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4042,13 +4084,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4269,6 +4311,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5887,6 +5948,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -6380,6 +6448,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -7147,6 +7254,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8989,19 +9137,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -9029,10 +9177,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9054,6 +9204,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@tanstack/react-query": "^5.96.1",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4",
     "react-aria-components": "^1.7.0",
+    "react-dom": "^19.2.4",
     "react-router-dom": "^7.6.0"
   },
   "devDependencies": {
@@ -32,6 +32,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9.39.4",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/frontend/scripts/check-env.mjs
+++ b/frontend/scripts/check-env.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Pre-flight environment variable check.
+ *
+ * Run before `vite dev` and `vite build`. Fails fast with a clear error
+ * message if any required variable is missing or obviously wrong.
+ *
+ * Usage:
+ *   node scripts/check-env.mjs
+ *
+ * To add a new required variable:
+ *   1. Add it to REQUIRED_VARS below with a description
+ *   2. Add it to .env.example with a comment
+ *   3. Document it in docs/environments.md
+ *
+ * To add a variable that's only required in production:
+ *   - Add it to PRODUCTION_REQUIRED_VARS instead
+ *
+ * This script is intentionally written as plain ESM JavaScript (not
+ * TypeScript) so it can run with `node` directly — no extra runtime
+ * dependency.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+
+// Best-effort: load .env.local then .env so we can validate the same way
+// Vite would. We don't depend on dotenv to avoid the install.
+function loadDotenv(filename) {
+  const path = join(projectRoot, filename);
+  if (!existsSync(path)) return;
+  const text = readFileSync(path, 'utf8');
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+loadDotenv('.env.local');
+loadDotenv('.env');
+
+const REQUIRED_VARS = [
+  {
+    name: 'VITE_API_BASE_URL',
+    description: 'Backend REST API base URL',
+    pattern: /^https?:\/\/.+/,
+  },
+];
+
+const PRODUCTION_REQUIRED_VARS = [
+  // Uncomment when ticket #32 (Sentry) lands:
+  // { name: 'VITE_SENTRY_DSN', description: 'Sentry DSN for error tracking' },
+];
+
+const env = process.env;
+const mode = env.NODE_ENV ?? env.VITE_MODE ?? 'development';
+const isProduction = mode === 'production';
+
+const errors = [];
+
+function checkVar(spec) {
+  const value = env[spec.name];
+  if (value === undefined || value === '') {
+    errors.push(`  ✗ ${spec.name} is required but not set — ${spec.description}`);
+    return;
+  }
+  if (spec.pattern && !spec.pattern.test(value)) {
+    errors.push(
+      `  ✗ ${spec.name} = "${value}" does not match expected format (${spec.pattern}) — ${spec.description}`,
+    );
+  }
+}
+
+REQUIRED_VARS.forEach(checkVar);
+if (isProduction) {
+  PRODUCTION_REQUIRED_VARS.forEach(checkVar);
+}
+
+if (errors.length > 0) {
+  process.stderr.write(`\n✗ Environment check failed (${mode} mode):\n\n`);
+  errors.forEach((line) => process.stderr.write(`${line}\n`));
+  process.stderr.write(
+    `\nFix the missing variables in your .env.local file (copy from .env.example to start),\n` +
+      `then re-run the command. See docs/environments.md for the full per-environment guide.\n\n`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(`✓ Environment check passed (${mode} mode)\n`);

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -1,0 +1,91 @@
+/**
+ * Sentry client-side initialization.
+ *
+ * This file is a TEMPLATE. To activate Sentry in a project:
+ *
+ * 1. Install the SDK:
+ *      npm install --save @sentry/react
+ * 2. Set VITE_SENTRY_DSN in the hosting provider's env (production + staging).
+ *    Local dev: leave unset to keep Sentry disabled — see initSentry() below.
+ * 3. Import and call initSentry() from main.tsx BEFORE createRoot().
+ * 4. (Optional) Wire the structured logger to Sentry — see the worked
+ *    example in skills/observability.md.
+ *
+ * The body below is intentionally inert (no Sentry SDK import) so the
+ * template builds without the @sentry/react dependency. Uncomment the
+ * import and the body when you adopt Sentry. The function signature
+ * stays the same so call sites in main.tsx don't need to change.
+ *
+ * See:
+ *   - skills/observability.md for the full setup, scrubbing, and tagging guide
+ *   - skills/security.md for the PII rules that drive the beforeSend scrubber
+ *   - frontend/src/lib/monitoring.ts for the wrapper around captureException
+ */
+
+// import * as Sentry from '@sentry/react';
+
+export function initSentry(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) {
+    // No DSN configured — typical in local dev. Skip init silently.
+    return;
+  }
+
+  // ===========================================================================
+  // Uncomment after running `npm install --save @sentry/react`
+  // ===========================================================================
+  //
+  // Sentry.init({
+  //   dsn,
+  //   environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE,
+  //   release: import.meta.env.VITE_SENTRY_RELEASE,
+  //
+  //   integrations: [
+  //     Sentry.browserTracingIntegration(),
+  //     Sentry.replayIntegration({
+  //       maskAllText: true,
+  //       blockAllMedia: true,
+  //     }),
+  //   ],
+  //
+  //   // Sample 10% of transactions in prod, all in dev.
+  //   tracesSampleRate: import.meta.env.MODE === 'production' ? 0.1 : 1.0,
+  //
+  //   // Replays only fire on errors. Sessions are off.
+  //   replaysSessionSampleRate: 0.0,
+  //   replaysOnErrorSampleRate: 1.0,
+  //
+  //   beforeSend(event) {
+  //     return scrubPIIFromEvent(event);
+  //   },
+  //
+  //   // Filter known noise. See skills/observability.md for the full list.
+  //   ignoreErrors: [
+  //     'ResizeObserver loop limit exceeded',
+  //     'Non-Error promise rejection captured',
+  //   ],
+  // });
+}
+
+// /**
+//  * PII scrubber for Sentry events. Drops request bodies, scrubs URL query
+//  * strings, and removes user.email/username if present. Opaque user.id is
+//  * preserved. See skills/security.md for the full PII policy.
+//  */
+// function scrubPIIFromEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+//   if (event.request?.data) delete event.request.data;
+//
+//   if (event.request?.url) {
+//     event.request.url = event.request.url.replace(
+//       /[?&](email|token|key|password)=[^&]*/gi,
+//       '$1=[REDACTED]',
+//     );
+//   }
+//
+//   if (event.user) {
+//     delete event.user.email;
+//     delete event.user.username;
+//   }
+//
+//   return event;
+// }

--- a/frontend/src/components/Button.stories.tsx
+++ b/frontend/src/components/Button.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from './Button';
+
+const meta = {
+  title: 'Primitives/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'ghost', 'danger'],
+    },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    isLoading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    children: 'Save changes',
+    onClick: () => undefined,
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    variant: 'danger',
+    children: 'Delete account',
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-3">
+      <Button {...args} size="sm">Small</Button>
+      <Button {...args} size="md">Medium</Button>
+      <Button {...args} size="lg">Large</Button>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+    children: 'Saving…',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,68 @@
+/**
+ * Button — the canonical button primitive for projects cloned from this template.
+ *
+ * Wraps a real <button> (NOT a div) so it gets keyboard focus, focus ring,
+ * and the right ARIA semantics for free. See skills/accessibility.md for the
+ * rationale.
+ *
+ * Variants and sizes are intentionally narrow. If you need a different
+ * style, extend the variant union here rather than adding inline classes
+ * at the call site.
+ */
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  isLoading?: boolean;
+  leadingIcon?: ReactNode;
+  children: ReactNode;
+}
+
+const VARIANT_CLASSES: Record<Variant, string> = {
+  primary: 'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-300',
+  secondary: 'bg-white text-slate-700 border border-slate-300 hover:bg-slate-50 disabled:bg-slate-100 disabled:text-slate-400',
+  ghost: 'bg-transparent text-slate-700 hover:bg-slate-100 disabled:text-slate-400',
+  danger: 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300',
+};
+
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-2.5 text-base',
+};
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  isLoading = false,
+  leadingIcon,
+  children,
+  disabled,
+  className = '',
+  type = 'button',
+  ...rest
+}: ButtonProps) {
+  const isDisabled = disabled || isLoading;
+
+  return (
+    <button
+      type={type}
+      disabled={isDisabled}
+      aria-busy={isLoading || undefined}
+      className={`inline-flex items-center gap-2 rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed ${VARIANT_CLASSES[variant]} ${SIZE_CLASSES[size]} ${className}`}
+      {...rest}
+    >
+      {isLoading ? (
+        <span aria-hidden="true" className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      ) : (
+        leadingIcon
+      )}
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/Card.stories.tsx
+++ b/frontend/src/components/Card.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from './Button';
+import { Card } from './Card';
+
+const meta = {
+  title: 'Primitives/Card',
+  component: Card,
+  tags: ['autodocs'],
+  args: {
+    title: 'Example card',
+    subtitle: 'A short description of what this card represents',
+    children: 'Card body content goes here. Cards are intentionally generic — wrap any content you want.',
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithoutHeader: Story = {
+  args: {
+    title: undefined,
+    subtitle: undefined,
+  },
+};
+
+export const WithButtons: Story = {
+  args: {
+    children: (
+      <div className="space-y-4">
+        <p className="text-sm text-slate-600">
+          Cards compose with other primitives. Buttons and other components
+          can sit inside the body and inherit the card's padding.
+        </p>
+        <div className="flex gap-2">
+          <Button variant="primary">Save</Button>
+          <Button variant="secondary">Cancel</Button>
+        </div>
+      </div>
+    ),
+  },
+};
+
+export const Grid: Story = {
+  render: () => (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-4xl">
+      {[1, 2, 3].map((i) => (
+        <Card key={i} title={`Item ${i}`} subtitle="Sample subtitle">
+          <p className="text-sm text-slate-600">
+            Cards in a responsive grid. Reflows from 1 column on mobile to 3 on desktop.
+          </p>
+        </Card>
+      ))}
+    </div>
+  ),
+};

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,31 @@
+/**
+ * Card — generic content container with consistent padding, rounded corners,
+ * and a subtle shadow. Use it instead of <div className="bg-white rounded ..."> at
+ * call sites so the visual treatment stays consistent across the app.
+ */
+
+import type { ReactNode } from 'react';
+
+interface CardProps {
+  children: ReactNode;
+  /** Optional title rendered as <h3> at the top of the card. */
+  title?: string;
+  /** Optional sub-text rendered under the title in muted colour. */
+  subtitle?: string;
+  /** Pass through extra Tailwind classes for one-off layout tweaks. */
+  className?: string;
+}
+
+export function Card({ children, title, subtitle, className = '' }: CardProps) {
+  return (
+    <section className={`bg-white rounded-2xl p-6 shadow-sm ${className}`}>
+      {(title || subtitle) && (
+        <header className="mb-4">
+          {title && <h3 className="text-base font-semibold text-slate-800">{title}</h3>}
+          {subtitle && <p className="mt-0.5 text-sm text-slate-500">{subtitle}</p>}
+        </header>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/lib/FeatureFlag.test.tsx
+++ b/frontend/src/lib/FeatureFlag.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { clearAllFlagOverrides, setFlagOverride } from './flags';
+import { FeatureFlag } from './FeatureFlag';
+
+describe('FeatureFlag', () => {
+  beforeEach(() => {
+    clearAllFlagOverrides();
+  });
+
+  afterEach(() => {
+    clearAllFlagOverrides();
+  });
+
+  it('renders children when the flag is on', () => {
+    setFlagOverride('example-csv-export', true);
+    render(
+      <FeatureFlag flag="example-csv-export">
+        <span>visible</span>
+      </FeatureFlag>,
+    );
+    expect(screen.getByText('visible')).toBeInTheDocument();
+  });
+
+  it('renders nothing by default when the flag is off', () => {
+    setFlagOverride('example-csv-export', false);
+    const { container } = render(
+      <FeatureFlag flag="example-csv-export">
+        <span>visible</span>
+      </FeatureFlag>,
+    );
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders the fallback when the flag is off and a fallback is provided', () => {
+    setFlagOverride('example-csv-export', false);
+    render(
+      <FeatureFlag flag="example-csv-export" fallback={<span>nope</span>}>
+        <span>visible</span>
+      </FeatureFlag>,
+    );
+    expect(screen.getByText('nope')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/FeatureFlag.tsx
+++ b/frontend/src/lib/FeatureFlag.tsx
@@ -1,0 +1,29 @@
+/**
+ * Component wrapper for conditional rendering based on a feature flag.
+ *
+ * Cleaner than ternaries when the conditional content is large. Lives in its
+ * own file so the React Fast Refresh ESLint rule
+ * (`react-refresh/only-export-components`) sees a component-only export.
+ *
+ * @example
+ * <FeatureFlag flag="example-csv-export" fallback={null}>
+ *   <button onClick={exportCsv}>Export CSV</button>
+ * </FeatureFlag>
+ */
+
+import type { ReactNode } from 'react';
+
+import { useFlag } from './useFlag';
+import type { FlagName } from './flags-config';
+
+interface FeatureFlagProps {
+  flag: FlagName;
+  children: ReactNode;
+  /** Optional fallback to render when the flag is OFF. */
+  fallback?: ReactNode;
+}
+
+export function FeatureFlag({ flag, children, fallback = null }: FeatureFlagProps) {
+  const enabled = useFlag(flag);
+  return enabled ? <>{children}</> : <>{fallback}</>;
+}

--- a/frontend/src/lib/flags-config.ts
+++ b/frontend/src/lib/flags-config.ts
@@ -1,0 +1,62 @@
+/**
+ * Central registry of feature flags.
+ *
+ * Adding a new flag:
+ *   1. Add the flag name to the `FLAG_NAMES` tuple below
+ *   2. Add a matching entry to `FLAG_METADATA` with description, default, owner, and expiry
+ *   3. Add a matching `VITE_FLAG_<UPPER_SNAKE>` entry to `.env.example`
+ *   4. Use it in code via `isEnabled('your-flag')` or `useFlag('your-flag')`
+ *
+ * Removing a flag:
+ *   - When a flag is fully rolled out (or abandoned), delete the code that
+ *     branches on it AND remove the entry from this file. Stale flags rot
+ *     into permanent dead code if you don't.
+ *
+ * Every flag MUST have an expiry date. Flags without an expiry are bugs.
+ * The expiry is when the flag should be reviewed for removal — it does not
+ * automatically disable the flag.
+ */
+
+// The single source of truth for valid flag names. Adding a flag here
+// makes it available everywhere via the typed `FlagName` union.
+export const FLAG_NAMES = [
+  'example-new-dashboard',
+  'example-csv-export',
+] as const;
+
+export type FlagName = (typeof FLAG_NAMES)[number];
+
+interface FlagMetadata {
+  /** One-line description of what the flag controls. */
+  description: string;
+  /** Default value if the env var is unset and no localStorage override exists. */
+  defaultValue: boolean;
+  /** Who owns this flag — used to chase removal when it expires. */
+  owner: string;
+  /** YYYY-MM-DD — date this flag should be reviewed for removal. */
+  expiresOn: string;
+}
+
+export const FLAG_METADATA: Record<FlagName, FlagMetadata> = {
+  'example-new-dashboard': {
+    description: 'Example flag — gates the redesigned dashboard layout',
+    defaultValue: false,
+    owner: 'tanay',
+    expiresOn: '2026-07-01',
+  },
+  'example-csv-export': {
+    description: 'Example flag — enables CSV export buttons on report tables',
+    defaultValue: false,
+    owner: 'tanay',
+    expiresOn: '2026-07-01',
+  },
+};
+
+/**
+ * Convert a flag name to its environment variable name.
+ *
+ * Example: 'example-new-dashboard' → 'VITE_FLAG_EXAMPLE_NEW_DASHBOARD'
+ */
+export function flagToEnvVar(flag: FlagName): string {
+  return `VITE_FLAG_${flag.replace(/-/g, '_').toUpperCase()}`;
+}

--- a/frontend/src/lib/flags.test.ts
+++ b/frontend/src/lib/flags.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearAllFlagOverrides,
+  clearFlagOverride,
+  isEnabled,
+  setFlagOverride,
+  subscribeToFlagChanges,
+} from './flags';
+import { FLAG_METADATA, flagToEnvVar } from './flags-config';
+
+describe('flagToEnvVar', () => {
+  it('converts kebab-case flag names to VITE_FLAG_UPPER_SNAKE', () => {
+    expect(flagToEnvVar('example-new-dashboard')).toBe('VITE_FLAG_EXAMPLE_NEW_DASHBOARD');
+    expect(flagToEnvVar('example-csv-export')).toBe('VITE_FLAG_EXAMPLE_CSV_EXPORT');
+  });
+});
+
+describe('isEnabled', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns the metadata default when no override and no env value is set', () => {
+    expect(isEnabled('example-new-dashboard')).toBe(FLAG_METADATA['example-new-dashboard'].defaultValue);
+  });
+
+  it('returns true when localStorage override is "true"', () => {
+    window.localStorage.setItem('flag:example-new-dashboard', 'true');
+    expect(isEnabled('example-new-dashboard')).toBe(true);
+  });
+
+  it('returns false when localStorage override is "false"', () => {
+    window.localStorage.setItem('flag:example-new-dashboard', 'false');
+    expect(isEnabled('example-new-dashboard')).toBe(false);
+  });
+
+  it('falls back to default when localStorage override is malformed', () => {
+    window.localStorage.setItem('flag:example-new-dashboard', 'maybe');
+    expect(isEnabled('example-new-dashboard')).toBe(FLAG_METADATA['example-new-dashboard'].defaultValue);
+  });
+
+  it('reads env var as fallback when no localStorage override is set', () => {
+    vi.stubEnv('VITE_FLAG_EXAMPLE_NEW_DASHBOARD', 'true');
+    expect(isEnabled('example-new-dashboard')).toBe(true);
+    vi.unstubAllEnvs();
+  });
+
+  it('localStorage override beats env var', () => {
+    vi.stubEnv('VITE_FLAG_EXAMPLE_NEW_DASHBOARD', 'false');
+    window.localStorage.setItem('flag:example-new-dashboard', 'true');
+    expect(isEnabled('example-new-dashboard')).toBe(true);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe('setFlagOverride / clearFlagOverride', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('writes to localStorage and isEnabled reflects the new value', () => {
+    setFlagOverride('example-csv-export', true);
+    expect(window.localStorage.getItem('flag:example-csv-export')).toBe('true');
+    expect(isEnabled('example-csv-export')).toBe(true);
+  });
+
+  it('clearFlagOverride removes the override and falls back to default', () => {
+    setFlagOverride('example-csv-export', true);
+    clearFlagOverride('example-csv-export');
+    expect(window.localStorage.getItem('flag:example-csv-export')).toBeNull();
+    expect(isEnabled('example-csv-export')).toBe(FLAG_METADATA['example-csv-export'].defaultValue);
+  });
+});
+
+describe('clearAllFlagOverrides', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('removes only flag-prefixed keys, not unrelated localStorage entries', () => {
+    setFlagOverride('example-new-dashboard', true);
+    setFlagOverride('example-csv-export', true);
+    window.localStorage.setItem('unrelated-key', 'should-survive');
+
+    clearAllFlagOverrides();
+
+    expect(window.localStorage.getItem('flag:example-new-dashboard')).toBeNull();
+    expect(window.localStorage.getItem('flag:example-csv-export')).toBeNull();
+    expect(window.localStorage.getItem('unrelated-key')).toBe('should-survive');
+  });
+});
+
+describe('subscribeToFlagChanges', () => {
+  let callback: ReturnType<typeof vi.fn<() => void>>;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    callback = vi.fn<() => void>();
+    unsubscribe = subscribeToFlagChanges(callback);
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    window.localStorage.clear();
+  });
+
+  it('fires when setFlagOverride dispatches the override event', () => {
+    setFlagOverride('example-new-dashboard', true);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('fires when clearFlagOverride dispatches the override event', () => {
+    setFlagOverride('example-new-dashboard', true);
+    callback.mockClear();
+    clearFlagOverride('example-new-dashboard');
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('stops firing after unsubscribe', () => {
+    unsubscribe();
+    setFlagOverride('example-new-dashboard', true);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/flags.ts
+++ b/frontend/src/lib/flags.ts
@@ -1,0 +1,107 @@
+/**
+ * Feature flag helpers (framework-agnostic).
+ *
+ * Resolution order (first match wins):
+ *   1. localStorage override   — for development, allows toggling without env changes
+ *   2. Environment variable    — VITE_FLAG_<UPPER_SNAKE> = 'true' | 'false'
+ *   3. defaultValue from FLAG_METADATA
+ *
+ * The localStorage override is intentionally available in production builds too,
+ * so support engineers can toggle a flag for a single user session without a
+ * redeploy. The override key is namespaced under `flag:` so it cannot collide
+ * with other localStorage usage.
+ *
+ * For React component usage (hook + wrapper component), see `flags-react.tsx`.
+ */
+
+import { FLAG_METADATA, flagToEnvVar } from './flags-config';
+import type { FlagName } from './flags-config';
+
+const OVERRIDE_PREFIX = 'flag:';
+export const OVERRIDE_EVENT = 'feature-flag-override-changed';
+
+function overrideKey(flag: FlagName): string {
+  return `${OVERRIDE_PREFIX}${flag}`;
+}
+
+function readLocalStorageOverride(flag: FlagName): boolean | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(overrideKey(flag));
+  if (raw === null) return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return null;
+}
+
+function readEnvValue(flag: FlagName): boolean | null {
+  const envVar = flagToEnvVar(flag);
+  const raw = (import.meta.env as Record<string, string | undefined>)[envVar];
+  if (raw === undefined) return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return null;
+}
+
+/**
+ * Synchronous flag check. Use in non-React code (utilities, event handlers).
+ * In components, prefer `useFlag` from `flags-react.tsx` so the UI updates
+ * when the override changes.
+ */
+export function isEnabled(flag: FlagName): boolean {
+  const override = readLocalStorageOverride(flag);
+  if (override !== null) return override;
+
+  const envValue = readEnvValue(flag);
+  if (envValue !== null) return envValue;
+
+  return FLAG_METADATA[flag].defaultValue;
+}
+
+/**
+ * Set a localStorage override for a flag. Persists across page reloads.
+ * Use in dev tooling or support flows. Dispatches an event so any
+ * `useFlag` hooks re-render immediately.
+ */
+export function setFlagOverride(flag: FlagName, value: boolean): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(overrideKey(flag), value ? 'true' : 'false');
+  window.dispatchEvent(new Event(OVERRIDE_EVENT));
+}
+
+/**
+ * Clear the localStorage override for a single flag, falling back to env / default.
+ */
+export function clearFlagOverride(flag: FlagName): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(overrideKey(flag));
+  window.dispatchEvent(new Event(OVERRIDE_EVENT));
+}
+
+/**
+ * Clear every flag override. Useful in tests and "reset to defaults" UI.
+ */
+export function clearAllFlagOverrides(): void {
+  if (typeof window === 'undefined') return;
+  const keysToRemove: string[] = [];
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i);
+    if (key && key.startsWith(OVERRIDE_PREFIX)) keysToRemove.push(key);
+  }
+  keysToRemove.forEach((key) => window.localStorage.removeItem(key));
+  window.dispatchEvent(new Event(OVERRIDE_EVENT));
+}
+
+/**
+ * Subscribe to flag override changes. Returns an unsubscribe function.
+ * Used internally by `useFlag` (`flags-react.tsx`) but also exported for
+ * advanced use cases.
+ */
+export function subscribeToFlagChanges(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => undefined;
+  window.addEventListener(OVERRIDE_EVENT, callback);
+  window.addEventListener('storage', callback);
+  return () => {
+    window.removeEventListener(OVERRIDE_EVENT, callback);
+    window.removeEventListener('storage', callback);
+  };
+}

--- a/frontend/src/lib/logger.test.ts
+++ b/frontend/src/lib/logger.test.ts
@@ -1,0 +1,137 @@
+// The no-console rule is disabled for this file via a pattern override in
+// `eslint.config.js`. The console spies in the "default transports" suite
+// require direct console references.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { logger, resetLogTransport, setLogTransport } from './logger';
+import type { LogEntry, LogTransport } from './logger';
+
+function createCapturingTransport(): { transport: LogTransport; entries: LogEntry[] } {
+  const entries: LogEntry[] = [];
+  return {
+    transport: {
+      emit(entry) {
+        entries.push(entry);
+      },
+    },
+    entries,
+  };
+}
+
+describe('logger', () => {
+  let capture: ReturnType<typeof createCapturingTransport>;
+
+  beforeEach(() => {
+    capture = createCapturingTransport();
+    setLogTransport(capture.transport);
+  });
+
+  afterEach(() => {
+    resetLogTransport();
+  });
+
+  describe('info', () => {
+    it('emits an info entry with the message', () => {
+      logger.info('hello');
+      expect(capture.entries).toHaveLength(1);
+      expect(capture.entries[0].level).toBe('info');
+      expect(capture.entries[0].message).toBe('hello');
+    });
+
+    it('attaches structured context when provided', () => {
+      logger.info('user clicked export', { feature: 'reports', action: 'export-csv' });
+      expect(capture.entries[0].context).toEqual({ feature: 'reports', action: 'export-csv' });
+    });
+
+    it('emits an ISO 8601 timestamp', () => {
+      logger.info('hello');
+      expect(capture.entries[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+  });
+
+  describe('warn', () => {
+    it('emits a warn entry', () => {
+      logger.warn('retrying failed request', { feature: 'api', statusCode: 503 });
+      expect(capture.entries[0].level).toBe('warn');
+      expect(capture.entries[0].context?.statusCode).toBe(503);
+    });
+  });
+
+  describe('error', () => {
+    it('emits an error entry with the Error object attached', () => {
+      const err = new Error('boom');
+      logger.error('something exploded', err, { feature: 'auth' });
+
+      expect(capture.entries[0].level).toBe('error');
+      expect(capture.entries[0].error).toBe(err);
+      expect(capture.entries[0].context?.feature).toBe('auth');
+    });
+
+    it('does not require an Error object', () => {
+      logger.error('something exploded but I do not have an Error');
+      expect(capture.entries[0].level).toBe('error');
+      expect(capture.entries[0].error).toBeUndefined();
+    });
+  });
+
+  describe('debug', () => {
+    it('emits a debug entry in development', () => {
+      // The default mode in vitest is 'test', not 'production', so debug should fire.
+      logger.debug('verbose detail', { traceId: 'abc-123' });
+      expect(capture.entries).toHaveLength(1);
+      expect(capture.entries[0].level).toBe('debug');
+    });
+  });
+});
+
+describe('setLogTransport / resetLogTransport', () => {
+  afterEach(() => {
+    resetLogTransport();
+  });
+
+  it('routes subsequent calls to the new transport', () => {
+    const a = createCapturingTransport();
+    const b = createCapturingTransport();
+
+    setLogTransport(a.transport);
+    logger.info('to a');
+    setLogTransport(b.transport);
+    logger.info('to b');
+
+    expect(a.entries.map((e) => e.message)).toEqual(['to a']);
+    expect(b.entries.map((e) => e.message)).toEqual(['to b']);
+  });
+
+  it('resetLogTransport restores the default transport', () => {
+    const captured = createCapturingTransport();
+    setLogTransport(captured.transport);
+    resetLogTransport();
+
+    // We can't easily assert which transport is active, but we can verify the
+    // captured transport is no longer receiving entries.
+    logger.info('after reset');
+    expect(captured.entries).toHaveLength(0);
+  });
+});
+
+describe('default transports', () => {
+  it('logs to console.info in development when no custom transport is set', () => {
+    resetLogTransport();
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    logger.info('via default transport');
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error level to console.error', () => {
+    resetLogTransport();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    logger.error('boom', new Error('inner'));
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,181 @@
+/**
+ * Structured logger for the frontend.
+ *
+ * Goals:
+ * 1. One canonical API across the app — `logger.info`, `logger.warn`,
+ *    `logger.error`, `logger.debug`. No more scattered `console.log`.
+ * 2. Every log is **structured** — a message string plus an optional context
+ *    object with typed fields. Searchable in any log aggregator.
+ * 3. Different transports for development and production:
+ *    - **Development:** pretty-printed to the browser console with colours
+ *      and the context object inlined for inspection.
+ *    - **Production:** delegated to a `LogTransport` that the host app
+ *      configures (typically pointed at Sentry breadcrumbs and Sentry
+ *      `captureException` for errors). The default production transport
+ *      is a no-op so the bundle stays clean if Sentry isn't wired up yet.
+ * 4. `debug` is **stripped in production** — calls return immediately.
+ * 5. PII and secrets must NEVER be passed in the context object. The
+ *    logger does not redact for you. See `docs/logging.md` for the rules.
+ *
+ * Sentry integration is intentionally deferred. When ticket #32 lands and
+ * Sentry is initialised in `main.tsx`, replace the default `noopTransport`
+ * via `setLogTransport` with one that calls `Sentry.addBreadcrumb` for
+ * info/warn/debug and `Sentry.captureException` for error.
+ */
+
+// This file is the only place direct console.* calls are allowed. The
+// no-console rule is disabled for this file via a pattern override in
+// `eslint.config.js`. Everywhere else in the app, use `logger`.
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Structured fields attached to a log entry. Add fields here as the app
+ * grows so the type guides usage. All fields are optional — pass only the
+ * ones that are meaningful for the call site.
+ *
+ * **Never** include PII (names, emails, full addresses) or secrets (tokens,
+ * passwords) in this object. Use opaque IDs instead.
+ */
+export interface LogContext {
+  /** Opaque user identifier. Never the user's email or name. */
+  userId?: string;
+  /** Logical feature area, e.g. 'shipping-bill-search', 'auth'. */
+  feature?: string;
+  /** What the user or system was trying to do, e.g. 'submit-form'. */
+  action?: string;
+  /** Distributed trace ID for correlating across services. */
+  traceId?: string;
+  /** HTTP status code, when relevant to the log line. */
+  statusCode?: number;
+  /** Duration in milliseconds, when timing an operation. */
+  durationMs?: number;
+  /** Anything else, opaque. Will be JSON-stringified by transports. */
+  [key: string]: unknown;
+}
+
+export interface LogEntry {
+  level: LogLevel;
+  message: string;
+  context?: LogContext;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+  /** The Error object, if this is an error log. */
+  error?: Error;
+}
+
+export interface LogTransport {
+  emit(entry: LogEntry): void;
+}
+
+/**
+ * Default production transport. No-op until ticket #32 (Sentry) lands.
+ */
+const noopTransport: LogTransport = {
+  emit() {
+    // intentionally empty
+  },
+};
+
+/**
+ * Default development transport. Pretty-prints to the browser console.
+ * Picks the right `console` method per level so devtools filtering works.
+ */
+const consoleTransport: LogTransport = {
+  emit(entry) {
+    const prefix = `[${entry.timestamp}] [${entry.level.toUpperCase()}]`;
+    const fn =
+      entry.level === 'error'
+        ? console.error
+        : entry.level === 'warn'
+          ? console.warn
+          : entry.level === 'debug'
+            ? console.debug
+            : console.info;
+    if (entry.error) {
+      fn(prefix, entry.message, entry.context ?? {}, entry.error);
+    } else if (entry.context) {
+      fn(prefix, entry.message, entry.context);
+    } else {
+      fn(prefix, entry.message);
+    }
+  },
+};
+
+const isProduction = import.meta.env.MODE === 'production';
+let activeTransport: LogTransport = isProduction ? noopTransport : consoleTransport;
+
+/**
+ * Replace the active log transport. Call once at app startup, typically
+ * after Sentry has been initialised.
+ *
+ * @example
+ * import * as Sentry from '@sentry/react';
+ * import { logger, setLogTransport } from './lib/logger';
+ *
+ * Sentry.init({ ... });
+ * setLogTransport({
+ *   emit(entry) {
+ *     if (entry.level === 'error' && entry.error) {
+ *       Sentry.captureException(entry.error, { extra: entry.context });
+ *     } else {
+ *       Sentry.addBreadcrumb({
+ *         level: entry.level === 'debug' ? 'debug' : entry.level,
+ *         message: entry.message,
+ *         data: entry.context,
+ *       });
+ *     }
+ *   },
+ * });
+ */
+export function setLogTransport(transport: LogTransport): void {
+  activeTransport = transport;
+}
+
+/**
+ * Reset to the default transport (console in dev, no-op in production).
+ * Useful in tests.
+ */
+export function resetLogTransport(): void {
+  activeTransport = isProduction ? noopTransport : consoleTransport;
+}
+
+function emit(level: LogLevel, message: string, context?: LogContext, error?: Error): void {
+  // `debug` is stripped in production for both performance and information
+  // hygiene reasons. Production code should never depend on debug logs.
+  if (level === 'debug' && isProduction) return;
+
+  const entry: LogEntry = {
+    level,
+    message,
+    context,
+    timestamp: new Date().toISOString(),
+    error,
+  };
+  activeTransport.emit(entry);
+}
+
+export const logger = {
+  /** Verbose information for debugging. Stripped in production. */
+  debug(message: string, context?: LogContext): void {
+    emit('debug', message, context);
+  },
+
+  /** Notable but expected events: user actions, navigation, completed flows. */
+  info(message: string, context?: LogContext): void {
+    emit('info', message, context);
+  },
+
+  /** Unexpected but recoverable conditions: degraded behavior, retries, fallbacks. */
+  warn(message: string, context?: LogContext): void {
+    emit('warn', message, context);
+  },
+
+  /**
+   * Errors that need investigation. Pass the original Error object so the
+   * transport can capture the stack trace and any cause chain.
+   */
+  error(message: string, error?: Error, context?: LogContext): void {
+    emit('error', message, context, error);
+  },
+};

--- a/frontend/src/lib/monitoring.ts
+++ b/frontend/src/lib/monitoring.ts
@@ -1,0 +1,66 @@
+/**
+ * Thin wrapper around Sentry capture functions.
+ *
+ * Components and modules import from this file instead of from `@sentry/react`
+ * directly. That way, if we ever switch providers, the swap is one file.
+ *
+ * Until ticket #32 (Sentry) is fully wired up — the SDK is installed and
+ * `initSentry()` is called from main.tsx — these functions are no-ops. The
+ * structured logger at `frontend/src/lib/logger.ts` is the primary way to
+ * surface errors; this module is here for the rare case when you want to
+ * report a non-Error signal to monitoring without going through the logger
+ * (e.g. a metric, a custom message).
+ *
+ * Most code should NOT call these directly. Use `logger.error(msg, err)` and
+ * configure the logger transport (see skills/observability.md) so every
+ * `logger.error` flows to Sentry automatically.
+ *
+ * See:
+ *   - skills/observability.md for the full Sentry guide
+ *   - frontend/src/lib/logger.ts for the primary error-reporting path
+ *   - frontend/sentry.client.config.ts for the Sentry init template
+ */
+
+// import * as Sentry from '@sentry/react';
+
+export type MonitoringLevel = 'info' | 'warning' | 'error';
+
+/**
+ * Structured fields attached to a monitoring entry. Mirrors `LogContext`
+ * from `frontend/src/lib/logger.ts` (created in ticket #38) so the same
+ * shape works in both modules. Defined locally here so this file doesn't
+ * depend on the logger module — the logger PR may merge before or after
+ * this one.
+ *
+ * NEVER include PII (emails, names, phone numbers, tokens). See
+ * skills/security.md for the full PII rules.
+ */
+export interface MonitoringContext {
+  userId?: string;
+  feature?: string;
+  action?: string;
+  traceId?: string;
+  statusCode?: number;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Capture an exception with optional structured context. No-op until the
+ * Sentry SDK is installed and the lines below are uncommented.
+ */
+export function captureException(_error: Error, _context?: MonitoringContext): void {
+  // Sentry.captureException(_error, { extra: _context });
+}
+
+/**
+ * Capture a message (no Error object) with optional structured context.
+ * No-op until Sentry is wired up.
+ */
+export function captureMessage(
+  _message: string,
+  _level: MonitoringLevel = 'info',
+  _context?: MonitoringContext,
+): void {
+  // Sentry.captureMessage(_message, { level: _level, extra: _context });
+}

--- a/frontend/src/lib/useFlag.test.tsx
+++ b/frontend/src/lib/useFlag.test.tsx
@@ -1,0 +1,38 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { clearAllFlagOverrides, setFlagOverride } from './flags';
+import { useFlag } from './useFlag';
+import type { FlagName } from './flags-config';
+
+function FlagProbe({ flag }: { flag: FlagName }) {
+  const enabled = useFlag(flag);
+  return <span data-testid="probe">{enabled ? 'on' : 'off'}</span>;
+}
+
+describe('useFlag', () => {
+  beforeEach(() => {
+    clearAllFlagOverrides();
+  });
+
+  afterEach(() => {
+    clearAllFlagOverrides();
+  });
+
+  it('renders the current value of the flag', () => {
+    setFlagOverride('example-new-dashboard', true);
+    render(<FlagProbe flag="example-new-dashboard" />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('on');
+  });
+
+  it('re-renders when the override changes after mount', () => {
+    render(<FlagProbe flag="example-new-dashboard" />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('off');
+
+    act(() => {
+      setFlagOverride('example-new-dashboard', true);
+    });
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('on');
+  });
+});

--- a/frontend/src/lib/useFlag.ts
+++ b/frontend/src/lib/useFlag.ts
@@ -1,0 +1,30 @@
+/**
+ * React hook for feature flag checks. Re-renders when the flag override changes.
+ *
+ * Lives in its own file so the React Fast Refresh ESLint rule
+ * (`react-refresh/only-export-components`) is not violated by mixing
+ * a hook export with component exports in the same file.
+ *
+ * For framework-agnostic checks, use `isEnabled` from `flags.ts`.
+ * For a wrapper component, use `<FeatureFlag>` from `FeatureFlag.tsx`.
+ *
+ * @example
+ * function Dashboard() {
+ *   const newLayout = useFlag('example-new-dashboard');
+ *   return newLayout ? <NewDashboard /> : <OldDashboard />;
+ * }
+ */
+
+import { useSyncExternalStore } from 'react';
+
+import { isEnabled, subscribeToFlagChanges } from './flags';
+import { FLAG_METADATA } from './flags-config';
+import type { FlagName } from './flags-config';
+
+export function useFlag(flag: FlagName): boolean {
+  return useSyncExternalStore(
+    subscribeToFlagChanges,
+    () => isEnabled(flag),
+    () => FLAG_METADATA[flag].defaultValue,
+  );
+}

--- a/skills/accessibility.md
+++ b/skills/accessibility.md
@@ -1,0 +1,269 @@
+# Accessibility Skill — WCAG 2.1 AA by Default
+
+## Purpose
+This skill defines the accessibility rules every Agent Space project must follow. The target is **WCAG 2.1 Level AA** — not AAA (aspirational), not Level A (insufficient for our enterprise customers).
+
+Every Agent Space app serves enterprise customers, many of whom have legal accessibility requirements (ADA, EU EAA, India RPwD Act). Accessibility is not optional, and it is much cheaper to bake in from the start than to retrofit.
+
+## The non-negotiables
+
+If you remember nothing else from this file, remember these five rules. Everything else is a refinement.
+
+1. **Use semantic HTML.** `<button>` for things that do something, `<a href>` for navigation, `<nav>`, `<main>`, `<section>`. Never `<div onClick>`.
+2. **Every interactive element is keyboard reachable.** Tab order is logical, focus is visible, no keyboard traps.
+3. **Every form input has a label** that is programmatically associated with it (`htmlFor`/`id` or wrapping `<label>`).
+4. **Every image has `alt`** — descriptive for informative images, `alt=""` for decorative.
+5. **Color contrast is at least 4.5:1** for body text, 3:1 for large text and UI components.
+
+## Semantic HTML
+
+Use the right element for the job. Don't reinvent built-ins with `div` + JavaScript.
+
+```tsx
+// BAD — div onClick is a keyboard and screen-reader trap
+<div onClick={handleClick} className="bg-blue-500 px-4 py-2">Save</div>
+
+// GOOD — real button, gets keyboard, focus, role for free
+<button type="button" onClick={handleClick} className="bg-blue-500 px-4 py-2">
+  Save
+</button>
+```
+
+```tsx
+// BAD — simulated link
+<span onClick={() => navigate('/home')}>Home</span>
+
+// GOOD — real link, works with middle-click, right-click, screen reader
+<Link to="/home">Home</Link>
+```
+
+```tsx
+// BAD — no landmarks, screen reader can't navigate by region
+<div>
+  <div>{header}</div>
+  <div>{content}</div>
+</div>
+
+// GOOD — landmarks let users jump straight to main content
+<>
+  <header>{header}</header>
+  <nav aria-label="Primary">{nav}</nav>
+  <main id="main-content">{content}</main>
+  <footer>{footer}</footer>
+</>
+```
+
+## Keyboard navigation
+
+Every interaction in the app must be possible with keyboard alone.
+
+- **Tab order matches visual order.** Don't use `tabIndex` to reorder. If the visual order is wrong, fix the DOM order.
+- **`tabIndex={0}`** to add an element to the tab order (rare — only for custom controls that aren't already focusable). Never `tabIndex` greater than 0.
+- **`tabIndex={-1}`** to remove an element from the tab order while keeping it programmatically focusable. Use this for elements you focus from JS (modals, error messages).
+- **Focus is always visible.** Tailwind's `focus:ring-2` and similar are required on every interactive element. Never `outline: none` without a replacement.
+- **No keyboard traps.** Modals trap focus *inside* the modal until dismissed; everywhere else, Tab and Shift+Tab move freely.
+- **Skip link.** Every page should start with a `<a href="#main-content">Skip to main content</a>` that is visually hidden until focused. Lets keyboard users skip the nav.
+
+```tsx
+// Skip link example — visually hidden until focused
+<a
+  href="#main-content"
+  className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:shadow"
+>
+  Skip to main content
+</a>
+```
+
+## Screen reader support
+
+- **`aria-label`** for icons-only buttons or controls without visible text. Be descriptive: `aria-label="Close dialog"`, not `aria-label="Close"`.
+- **`aria-labelledby`** when the label already exists somewhere else on the page — point to its `id`.
+- **`aria-describedby`** for supplementary descriptions (a hint, an error message). Not a substitute for a label.
+- **`aria-live`** for dynamic content the user needs to know about: form errors, toasts, status updates. Use `polite` for non-urgent, `assertive` for urgent (use sparingly).
+- **`role="alert"`** for critical messages (errors that block submission). Equivalent to `aria-live="assertive"` + `role="alert"`.
+- **Avoid ARIA when HTML can do the job.** First rule of ARIA: don't use ARIA. A `<button>` already has `role="button"` — adding `role="button"` is a code smell.
+
+```tsx
+// BAD — icon button with no accessible name
+<button onClick={onClose}><XIcon /></button>
+
+// GOOD — icon button with aria-label
+<button onClick={onClose} aria-label="Close dialog">
+  <XIcon aria-hidden="true" />
+</button>
+```
+
+```tsx
+// BAD — error message not announced
+{error && <p className="text-red-500">{error}</p>}
+
+// GOOD — live region announces the error when it appears
+{error && (
+  <p role="alert" className="text-red-500">
+    {error}
+  </p>
+)}
+```
+
+## Color and contrast
+
+- **Body text:** minimum **4.5:1** contrast ratio against the background.
+- **Large text (≥18pt or ≥14pt bold):** minimum **3:1**.
+- **UI components and graphical objects** (icons, focus rings, form borders): minimum **3:1**.
+- **Color is never the only signal.** Errors are red AND have an icon AND have text. "Available" is green AND has the word "Available". Color-blind users (8% of men) must not be locked out.
+- Use the **axe DevTools** browser extension to check contrast on every new screen.
+- Tailwind's default palette is mostly safe for body text but **always verify** combinations like `text-gray-400` on `bg-white` (around 3.5:1, fails AA for body).
+
+## Forms
+
+This is where most accessibility bugs hide.
+
+- **Every input has a `<label>`** with `htmlFor` matching the input's `id`. No exceptions.
+- **Placeholder is not a label.** Placeholder disappears when the user types. It's a hint, not a label.
+- **Required fields have `required` and `aria-required="true"`.**
+- **Errors are programmatically associated.** Use `aria-describedby` to point the input at its error message, and use `aria-invalid="true"` when the field has an error.
+- **Errors are announced.** Wrap the error in `role="alert"` so screen readers speak it as soon as it appears.
+- **Submit errors focus the first invalid field** so the user can immediately fix it. Don't make them tab back up.
+
+```tsx
+// BAD — placeholder as label, no error association, no announcement
+<input type="email" placeholder="Email" />
+{emailError && <span className="text-red-500">{emailError}</span>}
+
+// GOOD — label, association, announcement
+<div>
+  <label htmlFor="email" className="block text-sm font-medium">
+    Email <span aria-hidden="true">*</span>
+  </label>
+  <input
+    id="email"
+    type="email"
+    required
+    aria-required="true"
+    aria-invalid={!!emailError}
+    aria-describedby={emailError ? 'email-error' : undefined}
+    className={emailError ? 'border-red-500' : 'border-slate-300'}
+  />
+  {emailError && (
+    <p id="email-error" role="alert" className="mt-1 text-sm text-red-600">
+      {emailError}
+    </p>
+  )}
+</div>
+```
+
+## Focus management
+
+- **Focus visible.** Always. Use Tailwind's `focus-visible:ring-2 focus-visible:ring-brand`.
+- **Modal opens** → focus moves to the first focusable element inside the modal (or the close button if there's nothing else). On close, focus returns to the element that opened it.
+- **Route change** → focus moves to the new page's `<h1>` (or `<main>` element). Without this, screen reader users hear "loaded" with no idea where they are.
+- **Long lists or infinite scroll** → don't steal focus when new items load. Update an `aria-live="polite"` region with the new count instead.
+
+## Motion and animation
+
+- **Respect `prefers-reduced-motion`.** Some users get motion sickness from non-essential animation.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+- **Never autoplay video with sound.**
+- **Never use animation longer than 5 seconds** without a pause control.
+- **No flashing more than 3 times per second.** This is a seizure risk (WCAG 2.3.1).
+
+## Images
+
+- **Informative images:** `alt` describes what the image conveys, not what it looks like. `alt="Quarterly revenue chart"`, not `alt="bar chart"`.
+- **Decorative images:** `alt=""` (empty, but present). The screen reader skips it.
+- **SVG icons inside buttons with text:** `<svg aria-hidden="true">` so the screen reader reads the button's text only, not the icon.
+- **SVG icons that are the button's only label:** wrap with a button that has `aria-label`, and `aria-hidden="true"` on the SVG (see Forms section example above).
+
+## Common ARIA patterns
+
+| Pattern | When to use | Key attributes |
+|---|---|---|
+| Tabs | Tabbed interface | `role="tablist"`, `role="tab"`, `aria-selected`, `aria-controls`, `role="tabpanel"`, `aria-labelledby` |
+| Dialog | Modal, alert | `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-describedby`, focus trap |
+| Disclosure | Collapsible section, accordion | `<button aria-expanded aria-controls>`, content has matching `id` |
+| Combobox | Autocomplete | `role="combobox"`, `aria-autocomplete`, `aria-controls`, `aria-activedescendant` |
+| Menu | Right-click menu, dropdown menu | `role="menu"`, `role="menuitem"`, keyboard arrows |
+| Live region | Status updates, toasts | `aria-live="polite"` or `role="alert"` |
+
+**Strongly prefer Headless UI / Radix UI primitives** over hand-rolling these patterns. They get every detail right (focus management, keyboard handling, ARIA wiring) and have been battle-tested by thousands of teams. Hand-rolling a combobox is a six-month project.
+
+## Testing
+
+### Automated
+
+- **`jest-axe`** for component-level a11y tests. Add to every component test file:
+
+```tsx
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+it('has no accessibility violations', async () => {
+  const { container } = render(<MyComponent />);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+- **Storybook a11y addon** runs the same checks against every story. Configure in `.storybook/preview.ts` (see ticket 5.3 / Storybook setup).
+- **Lighthouse CI** runs accessibility checks on every PR (see ticket 5.5 / Lighthouse setup).
+
+### Manual
+
+Automated tests catch ~30% of accessibility issues. The other 70% require eyes, ears, and a keyboard.
+
+- **Tab through every page.** Can you reach every interactive element? Is the order logical? Is focus always visible?
+- **Use a screen reader.** macOS: VoiceOver (`Cmd+F5`). Windows: NVDA (free download). At minimum, navigate the home page once with the screen reader on.
+- **Zoom to 200%.** Does the layout still work? Are any elements cut off?
+- **Check with `prefers-reduced-motion: reduce`** in DevTools.
+- **axe DevTools browser extension.** Run on every new page before opening a PR.
+
+### When to test
+
+- **New component:** unit test with jest-axe + Storybook story checked by the a11y addon
+- **New page:** manual keyboard pass + axe DevTools scan + screen reader spot-check
+- **Refactor:** re-run the existing tests + axe DevTools to make sure no regressions
+
+## PR checklist (a11y items)
+
+These items live in `.github/pull_request_template.md` reviewer checklist. Both author and reviewer should verify:
+
+- [ ] Every interactive element is keyboard reachable
+- [ ] Tab order matches visual order
+- [ ] Focus is visible (no `outline: none` without replacement)
+- [ ] Every form input has a `<label>`
+- [ ] Every image has `alt` (or `alt=""` if decorative)
+- [ ] No `<div onClick>` — use `<button>` or `<a>`
+- [ ] Color is not the only signal for state
+- [ ] Color contrast is ≥ 4.5:1 for body text (axe DevTools or Lighthouse confirms)
+- [ ] If new ARIA was added, it's necessary (HTML doesn't already provide it)
+- [ ] Reduced-motion users get a quieter experience
+- [ ] At least one screen reader test was performed for new pages
+
+## Tools
+
+- **axe DevTools** (browser extension) — best automated checker, runs in DevTools
+- **Lighthouse** — built into Chrome DevTools, accessibility section
+- **WebAIM Contrast Checker** — https://webaim.org/resources/contrastchecker/
+- **VoiceOver** (macOS) — built in, `Cmd+F5` to toggle
+- **NVDA** (Windows) — free, https://www.nvaccess.org/
+- **Headless UI** — https://headlessui.com — accessible primitives for React
+- **Radix UI** — https://www.radix-ui.com — same idea, more components
+
+## Cross-references
+
+- `skills/frontend.md` — UI patterns (the a11y rules apply to everything written there)
+- `skills/testing.md` — `jest-axe` setup and accessibility test patterns
+- `.github/pull_request_template.md` — reviewer checklist with a11y items
+- `docs/runbooks/deployment-runbook.md` — Lighthouse a11y checks run as part of deploy verification (when ticket 5.5 lands)
+- WCAG 2.1 quick reference — https://www.w3.org/WAI/WCAG21/quickref/
+- ARIA Authoring Practices Guide — https://www.w3.org/WAI/ARIA/apg/

--- a/skills/git-workflow.md
+++ b/skills/git-workflow.md
@@ -1,0 +1,317 @@
+# Git Workflow Skill — Branches, Commits, and PRs
+
+## Purpose
+This is the canonical git workflow for every Agent Space project. Follow it whether you're a human dev or Claude Code. The goal is a git history that is **searchable, bisectable, and reviewable** — so that "what changed in November" or "which commit broke this" is a 10-second answer, not a half-hour spelunk.
+
+`CLAUDE.md` Section 5 has the one-paragraph version. This document has the full rules and examples.
+
+## Branching strategy
+
+**We use trunk-based development with short-lived feature branches.** One ticket = one branch = one PR. No long-lived `develop` or `release` branches. `main` is always shippable.
+
+### Branch naming
+
+Format: `{type}/{issue-number}-{short-kebab-description}`
+
+Allowed types:
+
+| Type | Use for |
+|---|---|
+| `feature/` | New functionality (new component, new endpoint, new page) |
+| `fix/` | Bug fix (something is broken, you make it work) |
+| `docs/` | Documentation only — no code changes |
+| `refactor/` | Restructure code without changing behaviour |
+| `chore/` | Tooling, config, dependencies, build system |
+| `test/` | Adding or fixing tests only |
+
+The `{issue-number}` is the GitHub issue number this branch addresses. Every branch must trace to a ticket.
+
+The `{short-kebab-description}` is 3–6 kebab-cased words. Long enough to be meaningful, short enough to fit in a tab.
+
+**Examples:**
+
+- `feature/24-date-range-filter`
+- `fix/89-search-button-not-clickable`
+- `docs/45-add-adr-template`
+- `refactor/102-extract-kpi-card`
+- `chore/46-set-up-dependabot`
+- `test/61-cover-error-states`
+
+**Never:**
+
+- `feature/new-stuff` (no issue number)
+- `feature/tanay/sidebar` (don't include people's names)
+- `Feature/Date-Range-Filter` (no PascalCase, no spaces)
+- `wip` (be specific)
+
+### When to create a branch
+
+- **One issue = one branch.** Don't bundle unrelated changes. If you discover a second bug while fixing the first, open a second issue and a second branch.
+- **Branch off `main`**, always. Pull latest first: `git checkout main && git pull origin main && git checkout -b feature/24-...`.
+- **Don't reuse branches.** If a PR is merged, delete the branch. Start fresh for the next ticket.
+
+## Commit messages
+
+We follow a **simplified Conventional Commits** format. Strict enough to be parseable by tooling, loose enough not to slow you down.
+
+### Format
+
+```
+{type}({scope}): {subject}
+
+{body — optional but encouraged for non-trivial changes}
+
+{footer — optional, used for breaking changes and issue refs}
+```
+
+- **Subject line:** 72 characters max, present tense imperative ("add", not "added"), no trailing period.
+- **Blank line** between subject and body.
+- **Body:** wrapped at 72 characters, explains the *why* not the *what* (the diff shows the what).
+- **Footer:** `Closes #24`, `Refs #89`, or `BREAKING CHANGE: ...` for breaking changes.
+
+### Allowed types
+
+| Type | Use for |
+|---|---|
+| `feat` | A new user-facing feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only |
+| `style` | Code style only (formatting, missing semicolons) — never user-visible |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or fixing tests |
+| `chore` | Build, deps, tooling, config |
+| `perf` | Performance improvement |
+| `ci` | CI/CD pipeline changes |
+
+### Scope
+
+Optional but useful when the project is large. Common scopes: `api`, `auth`, `dashboard`, `search`, `reports`. Pick a noun from the codebase, not a verb.
+
+### Examples — good
+
+```
+feat(search): add date range filter to shipping bills
+
+The previous search treated all dates equally, which made it
+impossible to scope queries to a quarter or fiscal year. The new
+filter wires the existing PageHeader DateRangeFilter into the search
+query state and re-runs the search on change.
+
+Closes #24
+```
+
+```
+fix(auth): clear React Query cache on logout
+
+Stale data from a previous user was leaking into the next session
+because the cache survived the route change. Now we call
+queryClient.clear() in the logout handler before navigating.
+
+Closes #89
+```
+
+```
+docs(adrs): record decision to use Tailwind over custom CSS
+
+Closes #45
+```
+
+```
+refactor(kpi-card): extract trend pill into its own component
+
+The KPICard render was getting unwieldy and the trend pill is reused
+in two other places. No behavioural change.
+```
+
+```
+chore(deps): bump react-query from 5.96 to 5.98 (patch group)
+```
+
+### Examples — bad
+
+```
+update stuff                            # ← what stuff? when? why?
+fixed bug                               # ← which bug?
+WIP                                     # ← never commit a WIP message to main
+Added the new date filter and also     # ← two changes, two commits
+fixed the auth bug
+asdfasdf                                # ← obvious
+Search.tsx                              # ← that's a file, not a message
+```
+
+### Commit cadence
+
+- **Commit early, commit often.** Small commits are easier to review, revert, and bisect.
+- **Each commit should be a self-contained logical unit.** If you can't describe a commit in one sentence, it's doing too much.
+- **Commit after every Claude Code prompt.** This is version-control insurance — see `CLAUDE.md` Section 5.
+
+## Pull requests
+
+### PR title
+
+The PR title should match the format of the most important commit in the branch:
+
+```
+feat(search): add date range filter to shipping bills
+```
+
+Or, if it matches the ticket title exactly (often the case for one-commit PRs), use the ticket title:
+
+```
+3.2 — Add date range filter component
+```
+
+Pick one convention per project and stick with it. The dev template uses ticket titles for PRs because they map directly to issues.
+
+### PR body
+
+Use the template at `.github/pull_request_template.md`. The required fields:
+
+1. **Summary** — 1–3 bullet points of what the PR does
+2. **Related issue** — `Closes #24` so GitHub auto-closes on merge
+3. **Test plan** — what you tested and how
+4. **Screenshots** — for any UI change, before and after
+
+The two example PR bodies below show the two ends of the spectrum.
+
+### Example — small change PR body
+
+```markdown
+## Summary
+- Replaces the placeholder date picker with the shared DateRangeFilter component.
+- No behavioural change — just unblocks ticket #28 which depends on the shared component.
+
+## Related issue
+Refs #24
+
+## Test plan
+- [x] `npm test` green
+- [x] Manual: opened the search page, picked a range, confirmed the filter chip updates
+- [x] Build green
+
+## Screenshots
+| Before | After |
+|---|---|
+| ![before](...) | ![after](...) |
+```
+
+### Example — large feature PR body
+
+```markdown
+## Summary
+- Adds a new "Reports" page with 6 report cards, a filter panel, and a preview table.
+- Lifts filter state into the page so the Generate button can apply filters atomically.
+- Adds 8 new mock data shapes for the report tables (CHA, country summary, ops, freight, GST, sales).
+- Wires up vitest config and the first 22 unit tests for the new components.
+
+## Related issue
+Closes #18 (Reports page)
+Closes #19 (vitest setup)
+
+## Architecture notes
+- Filter state lives in `ReportsPage` rather than `FilterPanel` so the Generate button can apply filters atomically. `FilterPanel` is now a controlled component.
+- The 6 report cards are config-driven from a `reports: ReportDef[]` array — adding a 7th report is one entry plus one column config plus one stats block.
+- Mock data is in `frontend/src/lib/mockData.ts`. When Mansi's API is ready, swap the imports for React Query hooks. The page components should not need to change.
+
+## What's deferred
+- Real CSV / Excel export — currently the buttons are visual only. Tracked in #28.
+- Coverage of the FilterPanel's preset buttons (only date input behaviour is tested). Tracked in #31.
+
+## Test plan
+- [x] `npm test` → 22 passing
+- [x] `npm run build` → green
+- [x] `npm run lint` → green
+- [x] Manual: clicked each report card, applied each filter combination, confirmed the table filters as expected
+- [x] Verified the Generated HH:MM:SS badge appears after clicking Generate
+
+## Screenshots
+[before / after for each of the 6 report cards]
+```
+
+### What blocks a PR vs what's a nit
+
+The reviewer playbook lives in [`code-review.md`](./code-review.md). Quick summary for PR authors:
+
+- **Blocker:** failing tests, lint errors, missing tests for new code, security issues, broken UI, type errors, accessibility regressions
+- **Suggestion:** the reviewer would do it differently — discuss and decide, not blocking
+- **Nit:** style, naming, micro-optimization — fix if cheap, ignore if not
+
+If a reviewer leaves a comment without a `blocker:` / `suggestion:` / `question:` / `nit:` prefix, treat it as `suggestion:`.
+
+## Merge strategy
+
+**Squash merge** for every PR. One PR = one commit on `main`.
+
+Why squash:
+
+- `main` history stays linear and readable — one line per feature, not 47 fixup commits
+- Bisecting is straightforward
+- Reverting a feature is one `git revert <sha>`
+- The PR body becomes the squashed commit body, so context is preserved
+
+The branch's individual commits live on the PR forever in GitHub's UI for anyone who wants the granular history.
+
+**Never:**
+
+- Merge commits on `main` (no `Merge pull request #...` clutter)
+- Force-push to `main`
+- Direct push to `main` (the branch protection rule should make this physically impossible)
+- Rebase merge (squash is cleaner)
+
+## Tags and releases
+
+Tags follow **semver**: `v1.2.3`.
+
+- **MAJOR (`v2.0.0`)** — breaking API changes (rare for an internal SPA, but possible if we publish a shared component library)
+- **MINOR (`v1.3.0`)** — new features, backwards compatible
+- **PATCH (`v1.2.4`)** — bug fixes only, no new features
+
+Tag from `main` only:
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v1.2.3 -m "Release v1.2.3 — see CHANGELOG.md"
+git push origin v1.2.3
+```
+
+Tag triggers (CI release workflow, deploy automation) are configured in `.github/workflows/`.
+
+## Setting up your local git config
+
+Run these once per machine when you join an Agent Space project. Replace the placeholders.
+
+```bash
+# Identity — match your GitHub email
+git config --global user.name "Your Name"
+git config --global user.email "you@agentspace.ai"
+
+# Editor for commit messages
+git config --global core.editor "code --wait"   # VS Code
+# git config --global core.editor "nano"        # or nano
+
+# Use the project commit message template
+git config --local commit.template .gitmessage
+
+# Pull = fetch + rebase, never merge
+git config --global pull.rebase true
+
+# Auto-prune deleted remote branches on fetch
+git config --global fetch.prune true
+
+# Helpful aliases
+git config --global alias.s "status -sb"
+git config --global alias.l "log --oneline --graph --decorate -20"
+git config --global alias.last "log -1 HEAD"
+```
+
+The `commit.template` line points your local git at `.gitmessage` in the repo root, which is a structured template that pre-fills the commit subject format. Set this once after cloning.
+
+## Cross-references
+
+- `CLAUDE.md` Section 5 — the one-paragraph summary of these rules
+- `.github/pull_request_template.md` — the PR body template
+- `.gitmessage` — the commit message template (set via `git config --local commit.template .gitmessage`)
+- `skills/code-review.md` — the reviewer-side playbook
+- `docs/runbooks/deployment-runbook.md` — what happens after the merge
+- Conventional Commits — https://www.conventionalcommits.org

--- a/skills/observability.md
+++ b/skills/observability.md
@@ -1,0 +1,328 @@
+# Observability Skill — Errors, Logs, and Performance
+
+## Purpose
+This skill defines how every Agent Space project handles observability: error tracking, structured logging, performance monitoring, and release tracking. The goal is *production bugs surface within minutes, not via customer complaints, with enough context to fix them in the next deploy.*
+
+The three pillars covered here are:
+
+1. **Error tracking** — Sentry (this skill)
+2. **Structured logging** — see `docs/logging.md` and `frontend/src/lib/logger.ts`
+3. **Performance monitoring** — Sentry performance + Lighthouse CI (covered in `skills/performance.md` when ticket #36 lands)
+
+## Why Sentry
+
+We picked Sentry because:
+
+- It's the de facto standard for SPA error tracking, so the team's prior experience transfers
+- Free tier is generous enough to evaluate any new project
+- React SDK auto-captures unhandled errors, breadcrumbs, and component stack traces with no per-component instrumentation
+- Performance monitoring is in the same product, so we don't run two services
+- Source map upload is well-supported for Vite, so production stack traces are readable
+
+If a future project requires self-hosted observability, the integration shape (init in `main.tsx`, swappable transport in the logger) makes it possible to swap providers without changing call sites. The logger and analytics modules already follow this pattern.
+
+## Setup overview
+
+The template ships with **scaffolding** for Sentry but **no DSN**. Each project that adopts the template fills in their DSN in env vars and the integration activates automatically.
+
+Files involved:
+
+- `frontend/sentry.client.config.ts` — client-side init (this skill ships it as a placeholder)
+- `frontend/src/lib/monitoring.ts` — thin wrapper around `Sentry.captureException` and `Sentry.captureMessage` so call sites don't depend on the Sentry SDK directly
+- `frontend/src/main.tsx` — calls `initSentry()` once at app boot, before rendering React
+- `.env.example` — documents `VITE_SENTRY_DSN`, `VITE_SENTRY_ENVIRONMENT`, `VITE_SENTRY_RELEASE`
+- `.github/workflows/ci.yml` — has a commented-out `sentry-cli sourcemaps upload` step that projects enable when they're ready
+
+When a project first activates Sentry:
+
+1. Create a Sentry project at https://sentry.io and copy the DSN
+2. Add `VITE_SENTRY_DSN` to the hosting provider's environment (production + staging)
+3. Add `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` to GitHub Actions secrets (for source map upload)
+4. Uncomment the source map upload step in `.github/workflows/ci.yml`
+5. Deploy. Trigger a test error. Confirm it lands in the Sentry dashboard.
+
+## Initialization pattern
+
+```ts
+// frontend/sentry.client.config.ts
+import * as Sentry from '@sentry/react';
+
+export function initSentry(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) {
+    // No DSN configured (typical in local dev) — skip init.
+    return;
+  }
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE,
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration({
+        maskAllText: true,
+        blockAllMedia: true,
+      }),
+    ],
+    tracesSampleRate: import.meta.env.MODE === 'production' ? 0.1 : 1.0,
+    replaysSessionSampleRate: 0.0,
+    replaysOnErrorSampleRate: 1.0,
+    beforeSend(event) {
+      return scrubPIIFromEvent(event);
+    },
+  });
+}
+```
+
+```tsx
+// frontend/src/main.tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { initSentry } from '../sentry.client.config';
+import './index.css';
+import { App } from './App';
+
+initSentry();
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+```
+
+The `initSentry` call must come **before** `createRoot`. Otherwise React's first render isn't instrumented and you'll miss the most important errors.
+
+## Error capture
+
+Two ways to capture errors:
+
+1. **Automatic** — unhandled exceptions, unhandled promise rejections, React error boundary errors. You don't write any code; the Sentry SDK installs the global handlers.
+2. **Explicit** — when you catch an error and want to send it. Use the `monitoring` module wrapper, not the Sentry SDK directly.
+
+```ts
+// frontend/src/lib/monitoring.ts
+import * as Sentry from '@sentry/react';
+import type { LogContext } from './logger';
+
+export function captureException(error: Error, context?: LogContext): void {
+  Sentry.captureException(error, {
+    extra: context,
+  });
+}
+
+export function captureMessage(message: string, level: 'info' | 'warning' | 'error' = 'info', context?: LogContext): void {
+  Sentry.captureMessage(message, {
+    level,
+    extra: context,
+  });
+}
+```
+
+Why a wrapper: components don't need to import the Sentry SDK directly. If we ever switch providers, the swap is one file. Same pattern as `logger.ts` and `analytics.ts`.
+
+### Wiring the structured logger to Sentry
+
+The structured logger at `frontend/src/lib/logger.ts` ships with a no-op transport in production (see `docs/logging.md`). When Sentry is enabled, swap the transport so error-level logs become Sentry events and other levels become breadcrumbs:
+
+```ts
+// frontend/src/main.tsx — after initSentry()
+import * as Sentry from '@sentry/react';
+import { setLogTransport } from './lib/logger';
+
+setLogTransport({
+  emit(entry) {
+    if (entry.level === 'error' && entry.error) {
+      Sentry.captureException(entry.error, { extra: entry.context });
+    } else if (entry.level === 'error') {
+      Sentry.captureMessage(entry.message, { level: 'error', extra: entry.context });
+    } else {
+      Sentry.addBreadcrumb({
+        level: entry.level === 'debug' ? 'debug' : entry.level === 'warn' ? 'warning' : 'info',
+        message: entry.message,
+        data: entry.context,
+      });
+    }
+  },
+});
+```
+
+This is the worked example referenced in the JSDoc on `setLogTransport`. Once it's in place, **every `logger.error(msg, err)` call in the codebase becomes a Sentry event** without changing any other code.
+
+## React error boundary
+
+Wrap the app's router (or the whole app) in `Sentry.ErrorBoundary`:
+
+```tsx
+import * as Sentry from '@sentry/react';
+
+<Sentry.ErrorBoundary
+  fallback={({ error, resetError }) => (
+    <div role="alert" className="p-6">
+      <h2 className="text-lg font-bold">Something went wrong</h2>
+      <p className="mt-2 text-slate-600">We've been notified and are looking into it.</p>
+      <button onClick={resetError} className="mt-4 px-4 py-2 bg-brand text-white rounded">
+        Try again
+      </button>
+    </div>
+  )}
+>
+  <App />
+</Sentry.ErrorBoundary>
+```
+
+The fallback is shown when a render or lifecycle method throws. Sentry captures the error, the component stack, and the user's recent breadcrumbs automatically.
+
+## Filtering noisy errors
+
+Some errors are not bugs. Filter them in `beforeSend` so Sentry's quota isn't burned on noise:
+
+```ts
+function shouldSendEvent(event: Sentry.ErrorEvent): boolean {
+  const message = event.message ?? event.exception?.values?.[0]?.value ?? '';
+
+  // Common false positives:
+  if (message.includes('ResizeObserver loop')) return false;
+  if (message.includes('Non-Error promise rejection captured')) return false;
+  if (message.includes('Network Error') && navigator.onLine === false) return false;
+
+  // Browser extensions throwing into the page:
+  const stack = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+  if (stack.some((frame) => frame.filename?.includes('chrome-extension://'))) return false;
+
+  return true;
+}
+
+Sentry.init({
+  ...
+  beforeSend(event) {
+    if (!shouldSendEvent(event)) return null;
+    return scrubPIIFromEvent(event);
+  },
+});
+```
+
+Add to this list as new noise patterns surface. Anything filtered should be **noise**, not real errors you want to ignore.
+
+## PII scrubbing
+
+Sentry can capture URLs, headers, request bodies, breadcrumbs, and component props. All of these can leak PII. The `beforeSend` hook is the chokepoint where you scrub.
+
+```ts
+function scrubPIIFromEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  // Drop request body — may contain form input
+  if (event.request?.data) delete event.request.data;
+
+  // Scrub query string PII patterns from the URL
+  if (event.request?.url) {
+    event.request.url = event.request.url.replace(/[?&](email|token|key)=[^&]*/gi, '$1=[REDACTED]');
+  }
+
+  // Drop user.email if for any reason it ended up here
+  if (event.user) {
+    delete event.user.email;
+    delete event.user.username;
+    // Keep event.user.id — opaque IDs are safe
+  }
+
+  return event;
+}
+```
+
+The full PII rules are in `skills/security.md`. The Sentry-specific reminders:
+
+- **Never** put a user's email or full name in `Sentry.setUser({ ... })`. Use the opaque ID only.
+- **Never** include free-text user input (search queries, comments, form values) in the breadcrumb data.
+- **Never** include auth tokens, API keys, or session IDs in event extras.
+- **Drop request bodies** by default. If you need them for debugging, scrub them per-field.
+
+## Adding user context (without PII)
+
+```ts
+import * as Sentry from '@sentry/react';
+import { logger } from './lib/logger';
+
+// On login
+Sentry.setUser({
+  id: user.id, // opaque, OK
+  // Do NOT add: email, name, phone, address
+});
+Sentry.setTag('plan', user.plan);
+Sentry.setTag('tenant_id', org.id);
+
+logger.info('user logged in', { userId: user.id, feature: 'auth' });
+
+// On logout
+Sentry.setUser(null);
+```
+
+`setUser` lets Sentry filter and group events by user. `setTag` is for searchable categorical fields. Both are stored on the session, so subsequent errors carry the same context until logout.
+
+## Tagging errors by feature area
+
+Use `logger.error(msg, err, { feature: 'shipping-bill-search' })` and the `feature` tag flows through to Sentry as part of the `extra` payload. To make features filterable in Sentry's UI, also call `Sentry.setTag('feature', name)` at the entry point of each feature, or wrap feature areas in `Sentry.withScope`:
+
+```ts
+Sentry.withScope((scope) => {
+  scope.setTag('feature', 'shipping-bill-search');
+  scope.setExtras({ filter: appliedFilters });
+  // ... do the work that might throw
+});
+```
+
+## Releases
+
+When CI deploys, it should tag the Sentry release with the deploy SHA so errors after the deploy can be linked to the exact commit.
+
+```yaml
+# .github/workflows/ci.yml — commented out by default until a project enables it
+# - name: Upload source maps to Sentry
+#   uses: getsentry/action-release@v1
+#   env:
+#     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+#     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+#   with:
+#     environment: production
+#     sourcemaps: ./frontend/dist/assets
+#     version: ${{ github.sha }}
+```
+
+Releases also let Sentry compute regression detection — *"this error first appeared in v1.2.3"* — which is invaluable for postmortems.
+
+## Local development
+
+In local dev, **Sentry is disabled** by default because `VITE_SENTRY_DSN` is unset in `.env.example`. The `initSentry()` function early-returns if there's no DSN. This is intentional — you don't want every dev mistake firing into the production Sentry project.
+
+If you do need Sentry locally (e.g., to test the integration), set `VITE_SENTRY_DSN` in your `.env.local` and use a separate Sentry project for development.
+
+## What Sentry is and isn't for
+
+**Use Sentry for:**
+
+- Catching unexpected runtime errors that users see
+- Capturing unhandled promise rejections
+- Tracking performance regressions (LCP, INP, slow API calls)
+- Linking errors to releases for postmortem analysis
+- Session replay on errors (with masking, see init config above)
+
+**Don't use Sentry for:**
+
+- Application logging — use `logger.info` / `logger.warn`. Sentry is for errors and signals.
+- Analytics — use the analytics module. Sentry is not a product analytics tool.
+- Performance monitoring of every page load — sample at 10% in production (set in `tracesSampleRate`)
+- Storing PII for debugging — never. Use opaque IDs and look up the rest in your admin tool.
+- Replacing structured logs — Sentry breadcrumbs are a small ring buffer (default 100 items). Don't rely on them for full audit history.
+
+## Cross-references
+
+- `docs/logging.md` — structured logging policy and the logger module
+- `frontend/src/lib/logger.ts` — the logger; pair with the Sentry transport above
+- `frontend/src/lib/monitoring.ts` — thin wrapper around Sentry capture functions
+- `frontend/sentry.client.config.ts` — the init function template
+- `skills/security.md` — full PII rules
+- `skills/performance.md` — Sentry performance monitoring (when ticket #36 lands)
+- Sentry React docs — https://docs.sentry.io/platforms/javascript/guides/react/
+- Sentry source maps — https://docs.sentry.io/platforms/javascript/sourcemaps/

--- a/skills/performance.md
+++ b/skills/performance.md
@@ -1,0 +1,230 @@
+# Performance Skill — Budgets, Patterns, and Lighthouse CI
+
+## Purpose
+This skill defines the performance rules and budgets every Agent Space project must follow. The goal is **fast on a mid-range Indian smartphone over a 4G connection**, which is the realistic worst-case for our enterprise customers' field staff. If it's fast there, it's fast everywhere.
+
+The pillars covered here:
+
+1. **Budgets** — what we measure and what's allowed (enforced by Lighthouse CI)
+2. **Bundle size** — code splitting, lazy loading, tree shaking
+3. **Images** — formats, sizing, lazy loading
+4. **Fonts** — loading strategy, subsetting
+5. **React** — when to memoize and when not
+6. **Network** — preconnect, prefetch, caching, React Query staleTime
+7. **Local profiling** — how to test locally before opening a PR
+
+## The budgets
+
+These live in `frontend/lighthouserc.json` and are enforced on every PR by `.github/workflows/lighthouse-ci.yml`. A PR that exceeds them will fail CI.
+
+| Metric | Budget | Severity | Why |
+|---|---|---|---|
+| Performance score | ≥ 90 | error | Composite Core Web Vitals score; matches Google's "good" threshold |
+| Accessibility score | ≥ 95 | error | We target WCAG 2.1 AA — see `skills/accessibility.md` |
+| Largest Contentful Paint (LCP) | < 2.5s | error | Google's "good" threshold |
+| Cumulative Layout Shift (CLS) | < 0.1 | error | Google's "good" threshold |
+| Interaction to Next Paint (INP) | < 200ms | error | Google's "good" threshold (replaced FID in 2024) |
+| Total Blocking Time (TBT) | < 300ms | error | Lab proxy for INP |
+| First Contentful Paint (FCP) | < 1.8s | warn | Useful early signal but not blocking |
+| Total bundle size | < 500KB | error | gzipped, all assets |
+| JS bundle size | < 300KB | error | gzipped — most of the 500KB budget |
+| Stylesheet size | < 50KB | warn | Tailwind purge keeps this small naturally |
+| Image weight | < 200KB | warn | Per page, not per image |
+| Best practices score | ≥ 95 | warn | Console errors, deprecated APIs, mixed content |
+
+**Why "warn" for some:** stylesheets and images vary by feature. We don't want a perfectly fine landing page failing CI because the marketing team added a hero image. The warns surface in the PR comment and prompt review, but don't block merge.
+
+**Tightening budgets:** when the team has shipped a few projects, ratchet the warnings into errors. Don't start strict — start at the current baseline and improve over time.
+
+## Bundle size
+
+The single biggest lever. A bloated bundle delays everything else.
+
+### Code splitting
+
+- **Route-level code splitting** with `React.lazy()` for every route. The login page shouldn't ship the dashboard's chart library. Vite's dynamic `import()` produces separate chunks automatically.
+
+```tsx
+import { lazy, Suspense } from 'react';
+
+const ReportsPage = lazy(() => import('./pages/ReportsPage'));
+
+<Suspense fallback={<LoadingSkeleton />}>
+  <ReportsPage />
+</Suspense>
+```
+
+- **Component-level lazy loading** for heavy components that aren't visible on first paint: charts, modals, complex forms.
+
+### Tree shaking
+
+- **Always import named exports**, not entire modules:
+  ```ts
+  // GOOD — tree-shakeable
+  import { format } from 'date-fns';
+
+  // BAD — pulls in the entire library
+  import * as dateFns from 'date-fns';
+  import dateFns from 'date-fns';
+  ```
+
+- **Avoid side-effect imports.** A library with `"sideEffects": false` in its `package.json` can be tree-shaken. Libraries that register globals (jQuery plugins, polyfills) cannot.
+
+### Dependency vetting
+
+- Check the bundle impact of any new dep on https://bundlephobia.com **before** installing.
+- A 5KB diff is fine. A 50KB diff for a one-line use case is not — write the inline code.
+- The `CLAUDE.md` Section 6 list bans Axios, Redux, Zustand, and MobX partly for this reason.
+- See `docs/dependency-upgrades.md` for the full new-dependency vetting flow.
+
+## Images
+
+Images are usually the biggest single asset on a page. Get them right.
+
+- **Use modern formats** — WebP for photos, AVIF if your hosting supports it, SVG for icons. PNG and JPEG only as fallbacks.
+- **Resize before upload.** A 4000x3000 image rendered at 200x150 wastes 95% of its bytes.
+- **`width` and `height` attributes** on every `<img>` to prevent layout shift (CLS):
+  ```html
+  <img src="logo.png" width="120" height="40" alt="Logo" />
+  ```
+- **`loading="lazy"`** for any image below the fold:
+  ```html
+  <img src="hero.webp" loading="lazy" alt="..." />
+  ```
+- **Responsive images** with `srcset` for hero / banner images:
+  ```html
+  <img
+    src="hero-800.webp"
+    srcset="hero-400.webp 400w, hero-800.webp 800w, hero-1200.webp 1200w"
+    sizes="(max-width: 600px) 400px, (max-width: 1000px) 800px, 1200px"
+    alt="..."
+  />
+  ```
+- **Decorative SVG inline** in JSX. Other images go in `public/` or imported as a URL.
+
+## Fonts
+
+- **Use `font-display: swap`** in your `@font-face` rules so text is visible during font load (avoids the "invisible text flash" — FOIT).
+- **Preload critical fonts** via `<link rel="preload">` in `index.html` so they fetch in parallel with the HTML.
+- **Subset fonts** to the characters you actually use. A full Latin font is ~30KB; the subset for your UI is often ~10KB.
+- **Self-host** instead of using Google Fonts CDN. Faster (no extra DNS lookup), CSP-friendlier, GDPR-friendlier.
+- **Limit to two font families.** One sans, one display, that's it. Three is rarely needed; four is a smell.
+
+## React performance
+
+Start un-optimized. Profile when there's a real problem. Memoize only when the profiler says so.
+
+### When to use memoization
+
+- **`React.memo`** — wrap a child that renders often with the same props but is expensive to render. Verify with the React DevTools Profiler before adding.
+- **`useMemo`** — when an expensive computation runs on every render and its inputs haven't changed. Sorting a 1000-item list, building a chart's tooltip data, etc.
+- **`useCallback`** — when a callback is passed to a memoized child as a prop. Without `useCallback`, the child re-renders on every parent render because the callback is a new reference each time. Without a memoized child, `useCallback` does literally nothing useful.
+
+### When NOT to memoize
+
+- **Small components.** The overhead of `React.memo` is bigger than the cost of a re-render for trivial components.
+- **Components that always receive new props.** If `<List items={filteredItems}>` gets a new array every render, `React.memo` won't help — the prop reference is different.
+- **Inside `useMemo`, things that are cheap to compute.** `useMemo(() => x + y, [x, y])` is slower than just `x + y`.
+- **Everywhere by default.** Premature memoization adds noise, makes refactoring harder, and slows down the dev loop.
+
+### Render hazards to fix without measuring
+
+These are always worth fixing, no profiler needed:
+
+- **State updates inside render functions.** Causes infinite loops; will crash the app.
+- **Expensive work in render** that doesn't depend on props or state. Move outside the component.
+- **Inline object/array literals in `useEffect` deps** — `useEffect(..., [{ foo }])` creates a new object every render. Pull the dep out.
+- **Calling `setState` in `useEffect` without a dep array** — runs on every render, infinite loop risk.
+
+## Network
+
+- **`<link rel="preconnect">`** for any third-party origin you'll fetch from on first paint (CDN, API, fonts host). Saves the DNS + TLS round trip.
+  ```html
+  <link rel="preconnect" href="https://api.example.com" crossorigin />
+  ```
+- **`<link rel="prefetch">`** for routes the user is likely to visit next. Vite's lazy chunks can be prefetched on hover or after first paint.
+- **HTTP/2 or HTTP/3** at the hosting level. All modern hosts (Vercel, Netlify, CloudFront) default to this.
+- **Compression.** Brotli > gzip. Both should be enabled at the hosting layer for text assets. Lighthouse will warn if compression is missing.
+- **Cache headers.** Hashed asset filenames (`index-AbCdEf12.js`) can use `Cache-Control: public, max-age=31536000, immutable`. The HTML itself uses `Cache-Control: no-cache, must-revalidate` so users always get the latest entrypoint.
+
+## React Query and caching
+
+Set `staleTime` deliberately on every query. The default of 0 means React Query refetches on every mount, which is wasteful and slow.
+
+- **`staleTime: 5 * 60 * 1000` (5 minutes)** — sensible default for most reads
+- **`staleTime: 30 * 1000` (30 seconds)** — fast-changing dashboards
+- **`staleTime: Infinity`** — for data that never changes during the session (config, enums)
+- **`gcTime: 30 * 60 * 1000` (30 min)** — keep cached data around even after components unmount, so navigation back is instant
+
+```ts
+useQuery({
+  queryKey: ['shipping-bills', filters],
+  queryFn: () => fetchBills(filters),
+  staleTime: 5 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
+});
+```
+
+See `skills/api.md` for the full React Query patterns.
+
+## Local profiling
+
+Before opening a PR for any non-trivial UI change, run Lighthouse locally. Don't wait for CI.
+
+```bash
+cd frontend
+npm run build
+npx serve dist        # or any other static file server
+# Open http://localhost:3000 in Chrome incognito
+# DevTools → Lighthouse → Mobile, Performance, Generate report
+```
+
+For Lighthouse CI specifically:
+
+```bash
+npm install -g @lhci/cli
+lhci autorun         # builds, runs Lighthouse, asserts against budgets
+```
+
+The output will tell you exactly which budget you exceeded and by how much. The HTML report breaks down which assets contributed the most to LCP and INP.
+
+### Performance debugging in DevTools
+
+- **Performance panel** — record a 5-second interaction, look for long tasks (red blocks > 50ms) and main-thread work
+- **Coverage panel** — shows unused JS and CSS. Anything > 50% unused is a code-splitting opportunity.
+- **Network panel** — slow 3G throttle to simulate field conditions. Disable cache when measuring first-load.
+- **React DevTools Profiler** — record a render-heavy interaction, find which components re-rendered and why
+
+## CI integration
+
+Lighthouse CI runs on every PR via `.github/workflows/lighthouse-ci.yml`. The workflow:
+
+1. Builds the project
+2. Runs `lhci autorun` against the static `dist/` output (no dev server needed)
+3. Asserts against the budgets in `lighthouserc.json`
+4. Uploads the full HTML report as a workflow artifact (downloadable from the PR's checks tab for 14 days)
+5. Comments the results on the PR (when `LHCI_GITHUB_APP_TOKEN` is configured — see Lighthouse CI docs)
+
+If the workflow fails, the report tells you exactly which metric or budget was exceeded and which assets contributed.
+
+## Adjusting the budgets
+
+The budgets in `lighthouserc.json` are deliberately set at Google's "good" thresholds. If a budget is consistently impossible to hit for legitimate reasons (e.g., a charting page that genuinely needs Recharts), the right move is:
+
+1. Discuss in the team channel
+2. Open an ADR documenting the deviation and the reason
+3. Adjust the budget in `lighthouserc.json` in the same PR as the ADR
+
+**Never** silently raise a budget to make a failing PR green. The budget is the project's documented contract with users; changing it should be a conscious decision, not a workaround.
+
+## Cross-references
+
+- `frontend/lighthouserc.json` — the budget configuration
+- `.github/workflows/lighthouse-ci.yml` — the CI workflow
+- `skills/frontend.md` — the broader frontend conventions
+- `skills/accessibility.md` — the accessibility budgets
+- `skills/api.md` — React Query patterns
+- `docs/dependency-upgrades.md` — new-dep vetting that protects bundle size
+- Web Vitals — https://web.dev/vitals/
+- Lighthouse CI docs — https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md
+- Bundlephobia — https://bundlephobia.com

--- a/skills/security.md
+++ b/skills/security.md
@@ -1,0 +1,197 @@
+# Security Skill — Secure-by-Default Patterns
+
+## Purpose
+This skill defines the security rules every Agent Space project must follow. It exists because Claude Code writes a lot of code automatically, and it needs explicit guardrails to avoid introducing OWASP-class bugs by accident. Read this before any feature touching authentication, API calls, user input, or secrets.
+
+The goal is **secure by default** — the easy path should also be the safe path. If a rule here makes a feature harder to build, that is intentional friction.
+
+## Threat model — the short version
+
+Every Agent Space app is a customer-facing SPA backed by a REST API. The realistic threats are:
+
+- **Stolen credentials** (auth token in localStorage, session hijacked from a logged dev console)
+- **XSS** (user input rendered without escaping, HTML injected via `dangerouslySetInnerHTML`)
+- **Supply chain** (a malicious npm package phoning home or skimming forms)
+- **CSRF** (a hostile site causing the user's browser to make authenticated requests)
+- **Leaked secrets** (`.env` committed by accident, API key embedded in client bundle)
+- **PII exposure** (full names, emails, addresses showing up in logs, error reports, or analytics events)
+
+Everything in this document maps back to one of those.
+
+## Authentication
+
+### Token storage
+- **Bearer tokens go in memory or in `httpOnly` cookies set by the backend.** Not localStorage. Not sessionStorage.
+- **Why:** localStorage is readable by any script on the page, including a compromised npm package or an XSS payload. `httpOnly` cookies are not.
+- **If the backend can only return tokens in the response body** (some APIs do), keep them in a module-scoped variable inside `/lib/api.ts` and re-fetch on page reload via the refresh flow. Do not persist them.
+- **Refresh tokens** must always be `httpOnly` cookies — never reachable from JS.
+
+### Logout hygiene
+- On logout, clear the in-memory token, clear the React Query cache (`queryClient.clear()`), revoke the refresh token via a backend call, and navigate to a public route.
+- Do not rely on a redirect alone — a stale tab keeps the cache.
+
+### Example
+
+```ts
+// BAD — token in localStorage, accessible to any script
+localStorage.setItem('authToken', token);
+const headers = { Authorization: `Bearer ${localStorage.getItem('authToken')}` };
+
+// GOOD — module-scoped, cleared on logout
+let authToken: string | null = null;
+export function setAuthToken(token: string | null) { authToken = token; }
+export function getAuthHeaders(): Record<string, string> {
+  return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+}
+```
+
+## Authorization
+
+- **The frontend never enforces authorization. The backend always does.** A hidden button is not security — it's UX. The corresponding endpoint must check the user's role.
+- Use role checks in components only to **show or hide UI**, never to gate access to data the user shouldn't see.
+- If a role check returns `true` in the UI but the API returns `403`, that is the **correct** behaviour and the UI must handle it gracefully (show a friendly "you don't have access" message).
+
+## Input validation
+
+- **Validate at the boundaries.** Forms validate on submit. API responses are typed and parsed. Anything in between can trust its inputs.
+- **Use a schema validator** (e.g. Zod) for any data that crosses the network — both inbound API responses and outbound form payloads. Don't rely on TypeScript types alone — they don't exist at runtime.
+- **Never trust the URL.** Query params, path params, hash fragments — all attacker-controlled. Sanitize before using.
+
+## XSS prevention
+
+React escapes string children by default. The dangerous patterns are:
+
+- `dangerouslySetInnerHTML` — only use it with content from a trusted source AND after sanitizing with DOMPurify (or equivalent)
+- `<a href={userInput}>` — sanitize the URL; reject anything that doesn't start with `http://`, `https://`, `mailto:`, or `/`
+- `<iframe src={userInput}>` — same as above, plus add `sandbox` and `referrerPolicy="no-referrer"`
+- `eval`, `Function()`, `setTimeout('...string...')` — never. ESLint should catch these.
+- `window.location = userInput` — sanitize first
+
+### Examples
+
+```tsx
+// BAD — direct injection of untrusted content
+<div dangerouslySetInnerHTML={{ __html: comment.body }} />
+
+// GOOD — sanitized
+import DOMPurify from 'dompurify';
+<div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.body) }} />
+```
+
+```tsx
+// BAD — javascript: URLs are executable
+<a href={user.website}>Their site</a>
+
+// GOOD — sanitize the URL
+function safeHref(url: string): string | undefined {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return ['http:', 'https:', 'mailto:'].includes(parsed.protocol) ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+<a href={safeHref(user.website)}>Their site</a>
+```
+
+## CSRF
+
+If the backend uses session cookies (rather than bearer tokens in headers), CSRF protection is mandatory:
+
+- Backend issues a CSRF token on login, returns it in the response or in a non-`httpOnly` cookie
+- Frontend reads the token and includes it in the `X-CSRF-Token` header on every state-changing request (POST/PUT/PATCH/DELETE)
+- Read-only requests (GET) don't need CSRF protection
+- The `/lib/api.ts` wrapper attaches the header automatically — components never touch it
+
+If the backend uses bearer tokens in headers (the more common case), CSRF is **not** a concern because cross-site requests don't carry the header. Document which model the backend uses in `[FILL_PER_PROJECT]`.
+
+## Secrets management
+
+- **Never commit a secret to git.** Even to a private repo. Even temporarily.
+- **`.env` files are never committed.** `.env.example` is the template, with placeholder values (`API_KEY=replace-me`).
+- **Vite-prefixed vars (`VITE_*`) are baked into the client bundle.** They are visible to anyone who downloads the JS. Use them only for non-secret values: API base URLs, public keys, feature flag flags. Real secrets stay server-side.
+- **`.gitignore` must include:** `.env`, `.env.local`, `.env.*.local`, `*.pem`, `*.key`, `*.crt`, `secrets/`
+- **If a secret is committed by accident** — it is compromised. Rotate it immediately, then `git filter-repo` to purge history (and force-push, with team coordination). Don't just delete it in a follow-up commit; the history still has it.
+- See `docs/dependency-upgrades.md` for the rules on adding new dependencies (every transitive dep is a supply chain risk).
+
+## Dependency security
+
+- **Run `npm audit` weekly.** The Dependabot configuration in `.github/dependabot.yml` automates most of this — see `docs/dependency-upgrades.md`.
+- **Never ignore a high or critical CVE** without a documented temporary workaround and a follow-up ticket to upgrade.
+- **Pin dependencies** in `package.json` and commit `package-lock.json`. Reproducible builds depend on it.
+- **Vet new dependencies** before adding them: last publish date, weekly downloads, maintainer reputation. Three lines of inline code beats a 50KB transitive dep tree.
+- **Forbidden packages** (per `CLAUDE.md` Section 6): Axios (use native `fetch`), Redux/Zustand/MobX (React Query + Context is sufficient).
+
+## Content Security Policy
+
+A baseline CSP for an Agent Space SPA looks like this. Set it as an HTTP header from the hosting provider — don't rely on the `<meta>` tag.
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'wasm-unsafe-eval';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: https:;
+  font-src 'self' data:;
+  connect-src 'self' https://api.example.com https://sentry.io;
+  frame-ancestors 'none';
+  base-uri 'self';
+  form-action 'self';
+```
+
+- `script-src 'self'` blocks inline scripts and external CDNs by default. If a third-party script is required, add its origin explicitly.
+- `'unsafe-inline'` for `style-src` is currently necessary for Tailwind v4's style injection. Track this — Tailwind may emit nonces in a future version.
+- `connect-src` must include every backend API origin and any monitoring/analytics endpoints (Sentry, etc.)
+- `frame-ancestors 'none'` prevents the app from being embedded in another site (clickjacking protection)
+
+## Secure API patterns
+
+- **HTTPS only.** Never `http://` URLs in production. The `apiClient` in `/lib/api.ts` should refuse non-HTTPS in production builds.
+- **No credentials in URLs.** Tokens, API keys, session IDs go in headers. `/api/users?token=abc123` is wrong because URLs land in browser history, server logs, and Referer headers.
+- **No PII in logs.** Use opaque IDs (`userId: 'usr_abc'`), never `email: 'alice@example.com'`. See the logger documentation in `docs/logging.md` for the full rules.
+- **Set `Cache-Control: no-store`** on responses containing user data.
+- **CORS** is enforced by the backend. The frontend cannot bypass it. Don't try.
+
+## What is PII
+
+PII (personally identifiable information) is anything that can be tied back to a real person. **Do not log it, do not put it in error reports, do not put it in analytics events, do not put it in URLs.**
+
+- Names (full or first name)
+- Email addresses
+- Phone numbers
+- Physical addresses
+- Government IDs (Aadhaar, SSN, passport numbers)
+- Financial info (account numbers, card numbers, CVV, full IBAN)
+- Health information
+- Free-text user input (comments, search queries — may contain PII)
+- IP addresses (depending on jurisdiction, e.g. GDPR considers them PII)
+- Precise geolocation
+
+**Use opaque IDs instead.** When debugging a specific user, look up their record by ID in the admin tool — never embed the identifying info in the log/error.
+
+This is also covered in `docs/logging.md` (logger rules) and `frontend/src/lib/analytics.ts` (analytics scrubbing) when those exist.
+
+## PR-time security checklist
+
+Every PR — including Dependabot PRs — should pass this checklist before merge:
+
+- [ ] No hardcoded secrets, tokens, or API keys (grep the diff for suspicious strings)
+- [ ] No new `dangerouslySetInnerHTML` without DOMPurify
+- [ ] No `eval`, `Function()`, or `setTimeout('string')`
+- [ ] All user input that ends up in a URL is sanitized
+- [ ] All API responses are validated against a schema (Zod or equivalent)
+- [ ] No PII in `console.log`, `logger.*`, error messages, or analytics events
+- [ ] `npm audit` shows no new high/critical CVEs (Dependabot will catch this on the next cycle if missed)
+- [ ] No new third-party dependency without justification in the PR description (per `CLAUDE.md` Section 6)
+- [ ] If the PR touches auth or sessions, it has been reviewed by Chinmay
+- [ ] Tests cover the security-relevant paths (auth flows, input validation, role checks)
+
+## Cross-references
+
+- `CLAUDE.md` Section 6 — what NOT to do (the master rule list)
+- `skills/api.md` — auth flows, fetch wrapper, error handling
+- `docs/logging.md` — what to put / not put in `LogContext`
+- `docs/dependency-upgrades.md` — Dependabot policy and dependency vetting
+- `.github/dependabot.yml` — automated dependency scanning config
+- OWASP Top 10 — https://owasp.org/Top10/
+- React security cheatsheet — https://cheatsheetseries.owasp.org/cheatsheets/React_Security_Cheat_Sheet.html


### PR DESCRIPTION
## Summary
PRs #47-#61 had merge conflicts after PRs #79 and #95 landed. This PR brings all 43 missing files onto main in one shot:

- **6 skill files:** security, accessibility, git-workflow, observability, performance, .gitmessage
- **8 docs:** dependency-upgrades, environments, logging, ADRs (README + template + 2 examples), runbooks (README + deployment + incident + postmortem)
- **10 code helpers:** logger + test, feature flags (5 files + 3 tests), monitoring, sentry config, check-env script
- **4 Storybook files:** config + Button + Card components with stories
- **2 CI files:** dependabot.yml, lighthouse-ci.yml
- **4 configs:** lighthouserc.json, 3 per-env .example files
- **Fix:** installs `@vitest/coverage-v8` so `npm run test:coverage` works

## Verification
- 5 test files, 35 tests, all passing
- Coverage: 88.57% statements, 95.34% lines (above 80% threshold)
- Lint clean, vite build green
- Pre-commit hooks (eslint + tsc + vitest related) all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)