### PR TITLE
fix: commit-msg hook propagates commitlint failures

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,8 +1,16 @@
 # Enforce conventional commit format.
 # Install: npm install -D @commitlint/cli @commitlint/config-conventional
-# If commitlint is not installed, skip with a warning.
-if command -v npx &> /dev/null && [ -f "commitlint.config.js" ]; then
-  npx --no-install commitlint --edit "$1" 2>/dev/null || {
+#
+# Detection logic:
+#   - If commitlint binary is installed (resolvable by npx --no-install), run
+#     it and let its exit code determine whether the commit proceeds.
+#   - If it's NOT installed, skip with a warning (don't block dev workflow).
+
+if [ -f "commitlint.config.js" ] && command -v npx &> /dev/null; then
+  if npx --no-install commitlint --version &> /dev/null; then
+    # commitlint IS installed — run it and propagate its exit code.
+    npx --no-install commitlint --edit "$1"
+  else
     echo "⚠️  commitlint not installed — skipping format check. Run: npm install -D @commitlint/cli @commitlint/config-conventional"
-  }
+  fi
 fi


### PR DESCRIPTION
## Summary
Previous hook used `commitlint ... 2>/dev/null || { echo 'skipping' }` which swallowed real commitlint failures and let bad commits through. Fix detects whether commitlint is installed via a version probe before deciding to enforce or skip.

## Test plan
- [x] Bad message ('bad message no colon') is now BLOCKED with code 1
- [x] Good message ('test: ...') is allowed through